### PR TITLE
Replace server/config.ts with env vars

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,6 +1,0 @@
-const config = {
-  port: 4000,
-  caching: true
-}
-
-export { config }

--- a/server/datasources/requestsDataSource.ts
+++ b/server/datasources/requestsDataSource.ts
@@ -1,21 +1,24 @@
 import { DataSource } from 'apollo-datasource'
 import { Types } from 'mongoose'
+import dotenv from 'dotenv'
 
 import { Request, RequestDocument, RequestInterface } from '../models/requestModel'
-import { config } from '../config'
 import { RequestsCache } from '../database/cache'
+
+dotenv.config()
+const CACHING = process.env.CACHING == 'TRUE'
 
 export default class RequestDataSource extends DataSource {
   async getRequestById(rawId: string): Promise<RequestInterface> {
     const id = Types.ObjectId(rawId)
     let result
 
-    if (config.caching) {
+    if (CACHING) {
       result = RequestsCache.getData().filter(request => request._id.equals(id))[0]
     } else {
-      Request.findById(id).exec()
+      await Request.findById(id).exec()
         .then((res) => {
-          result = res[0]
+          result = res
         })
         .catch((err) => {
           console.error(err)
@@ -28,10 +31,10 @@ export default class RequestDataSource extends DataSource {
   async getRequests(): Promise<Array<RequestInterface>> {
     let result
 
-    if (config.caching) {
+    if (CACHING) {
       result = RequestsCache.getData()
     } else {
-      Request.find().exec()
+      await Request.find().exec()
         .then((res) => {
           result = res
         })

--- a/server/datasources/requestsDataSource.ts
+++ b/server/datasources/requestsDataSource.ts
@@ -1,6 +1,6 @@
 import { DataSource } from 'apollo-datasource'
-import { Types } from 'mongoose'
 import dotenv from 'dotenv'
+import { Types } from 'mongoose'
 
 import { Request, RequestDocument, RequestInterface } from '../models/requestModel'
 import { RequestsCache } from '../database/cache'

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,7 +2,6 @@ import { ApolloServer } from 'apollo-server'
 import { connectDB } from './database/mongoConnection'
 import dotenv from 'dotenv'
 
-import { config } from './config'
 import RequestDataSource from './datasources/requestsDataSource'
 import { RequestsCache } from './database/cache'
 import { resolvers } from './graphql/resolvers'
@@ -15,6 +14,8 @@ import { typeDefs } from './graphql/schema'
 // //-----------------------------------------------------------------------------
 
 dotenv.config()
+const CACHING = process.env.CACHING == 'TRUE'
+const PORT = process.env.PORT
 
 // -----------------------------------------------------------------------------
 // MONGODB CONNECTION AND DATA SOURCES FOR APOLLO
@@ -22,7 +23,7 @@ dotenv.config()
 
 // connect to MongoDB and setup data sources
 connectDB(() => {
-  if (config.caching) {
+  if (CACHING) {
     RequestsCache.init()
   }
 })
@@ -39,7 +40,6 @@ const server = new ApolloServer({
   })
 })
 
-const port = config.port
-server.listen({ port }).then(({ url }) => {
+server.listen({ port: PORT }).then(({ url }) => {
   console.log(`🚀 Server ready at ${url}`)
 })


### PR DESCRIPTION
The following `.env` file has been uploaded to Blueprint's vault using secret manager:
```
MONGO_URI=<redacted>
PORT=4000
CACHING=TRUE
```
To turn caching off, set `CACHING` to any value other than `TRUE`.

Pull the `.env` file by setting up [secret manager](https://www.notion.so/uwblueprintexecs/Secret-Management-2d5b59ef0987415e93ec951ce05bf03e#3008f54889ab4b0cacfa276cbc43e613) and running the following command in the root of the project:
```
vault kv put kv/pregnancy-centre CLIENT_ENV_VARS=@client/.env SERVER_ENV_VARS=@server/.env
```


Also fixed some bugs for when caching is turned off.
