### PR TITLE
Add RequestGroup Graphql endpoint

### DIFF
--- a/server/database/cache.ts
+++ b/server/database/cache.ts
@@ -1,5 +1,6 @@
 import { Document, Model, Query } from 'mongoose'
 import { Request } from '../models/requestModel'
+import { RequestGroup } from '../models/requestGroupModel'
 
 class Cache {
   name: string;
@@ -35,5 +36,6 @@ class Cache {
 }
 
 const RequestsCache = new Cache('Request', Request, Request.find())
+const RequestGroupsCache = new Cache('RequestGroup', RequestGroup, RequestGroup.find())
 
-export { Cache, RequestsCache }
+export { Cache, RequestsCache, RequestGroupsCache }

--- a/server/datasources/requestGroupsDataSource.ts
+++ b/server/datasources/requestGroupsDataSource.ts
@@ -56,6 +56,7 @@ export default class RequestGroupDataSource extends DataSource {
       _id: requestGroup._id,
       name: requestGroup.name,
       description: requestGroup.description,
+      deleted: requestGroup.deleted,
       requirements: requestGroup.requirements,
       image: requestGroup.image,
       requestTypes: requestGroup.requestTypes,

--- a/server/datasources/requestGroupsDataSource.ts
+++ b/server/datasources/requestGroupsDataSource.ts
@@ -1,0 +1,64 @@
+import { DataSource } from 'apollo-datasource'
+import dotenv from 'dotenv'
+import { Types } from 'mongoose'
+
+import { RequestGroup, RequestGroupDocument, RequestGroupInterface } from '../models/requestGroupModel'
+import { RequestGroupsCache } from '../database/cache'
+
+dotenv.config()
+const CACHING = process.env.CACHING == 'TRUE'
+
+// TODO(meganniu): replace getRequestGroupById with getById
+// TODO(meganniu): replace getRequestGroups with getAll
+// TODO(meganniu): make factory class where generic is the mongoose model. factory class should implement getById and getAll
+// TODO(meganniu): stadardize plurality of variable/class names (request vs requests, requestGroup vs requestGroups)
+
+export default class RequestGroupDataSource extends DataSource {
+  async getRequestGroupById(rawId: string): Promise<RequestGroupInterface> {
+    const id = Types.ObjectId(rawId)
+    let result
+
+    if (CACHING) {
+      result = RequestGroupsCache.getData().filter(requestGroup => requestGroup._id.equals(id))[0]
+    } else {
+      await RequestGroup.findById(id).exec()
+        .then((res) => {
+          result = res
+        })
+        .catch((err) => {
+          console.error(err)
+        })
+    }
+
+    return this.requestGroupReducer(result)
+  }
+
+  async getRequestGroups(): Promise<Array<RequestGroupInterface>> {
+    let result
+
+    if (CACHING) {
+      result = RequestGroupsCache.getData()
+    } else {
+      await RequestGroup.find().exec()
+        .then((res) => {
+          result = res
+        })
+        .catch((err) => {
+          console.error(err)
+        })
+    }
+
+    return result.map((requestGroup) => this.requestGroupReducer(requestGroup))
+  }
+
+  requestGroupReducer(requestGroup: RequestGroupDocument): RequestGroupInterface {
+    return {
+      _id: requestGroup._id,
+      name: requestGroup.name,
+      description: requestGroup.description,
+      requirements: requestGroup.requirements,
+      image: requestGroup.image,
+      requestTypes: requestGroup.requestTypes,
+    }
+  }
+}

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -1,5 +1,5 @@
-import { RequestInterface } from '../models/requestModel'
 import { RequestGroupInterface } from '../models/requestGroupModel'
+import { RequestInterface } from '../models/requestModel'
 
 const resolvers = {
   Query: {

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -1,9 +1,12 @@
 import { RequestInterface } from '../models/requestModel'
+import { RequestGroupInterface } from '../models/requestGroupModel'
 
 const resolvers = {
   Query: {
     request: (_, { id }, { dataSources }): RequestInterface => dataSources.requests.getRequestById(id),
-    requests: (_, __, { dataSources }): Array<RequestInterface> => dataSources.requests.getRequests()
+    requests: (_, __, { dataSources }): Array<RequestInterface> => dataSources.requests.getRequests(),
+    requestGroup: (_, { id }, { dataSources }): RequestGroupInterface => dataSources.requestGroups.getRequestGroupById(id),
+    requestGroups: (_, __, { dataSources }): Array<RequestGroupInterface> => dataSources.requestGroups.getRequestGroups()
   }
 }
 

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -26,6 +26,7 @@ const typeDefs = gql`
         _id: ID
         name: String
         description: String
+        deleted: Boolean
         requirements: String
         image: String
         requestTypes: [RequestType]

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -33,6 +33,8 @@ const typeDefs = gql`
     type Query {
         request(id: ID): Request
         requests: [Request]
+        requestGroup(id: ID): RequestGroup
+        requestGroups: [RequestGroup]
     }
 `
 

--- a/server/models/requestGroupModel.ts
+++ b/server/models/requestGroupModel.ts
@@ -4,6 +4,7 @@ interface RequestGroupInterface {
   _id: Types.ObjectId
   name: string
   description: string
+  deleted: boolean
   requirements: string
   image: string
   requestTypes: [Types.ObjectId]

--- a/server/models/requestGroupModel.ts
+++ b/server/models/requestGroupModel.ts
@@ -6,7 +6,7 @@ interface RequestGroupInterface {
   description: string
   requirements: string
   image: string
-  requestTypes: [RequestGroupDocument]
+  requestTypes: [Types.ObjectId]
 }
 
 type RequestGroupDocument = RequestGroupInterface & Document;

--- a/server/models/requestTypeModel.ts
+++ b/server/models/requestTypeModel.ts
@@ -1,5 +1,7 @@
 import { Document, model, Schema, Types } from 'mongoose'
 
+
+// TODO: Add `deleted` field to RequestTypeDocument and graphql schema
 interface RequestTypeDocument extends Document {
   _id: Types.ObjectId
   name: string

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,9 +2,9 @@ import { ApolloServer } from 'apollo-server'
 import { connectDB } from './database/mongoConnection'
 import dotenv from 'dotenv'
 
+import { RequestGroupsCache, RequestsCache } from './database/cache'
 import RequestDataSource from './datasources/requestsDataSource'
 import RequestGroupDataSource from './datasources/requestGroupsDataSource'
-import { RequestsCache, RequestGroupsCache } from './database/cache'
 import { resolvers } from './graphql/resolvers'
 import { typeDefs } from './graphql/schema'
 
@@ -38,7 +38,7 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   dataSources: () => ({
-    requests: new RequestGroupDataSource(),
+    requests: new RequestDataSource(),
     requestGroups: new RequestGroupDataSource(),
   })
 })

--- a/server/server.ts
+++ b/server/server.ts
@@ -3,7 +3,8 @@ import { connectDB } from './database/mongoConnection'
 import dotenv from 'dotenv'
 
 import RequestDataSource from './datasources/requestsDataSource'
-import { RequestsCache } from './database/cache'
+import RequestGroupDataSource from './datasources/requestGroupsDataSource'
+import { RequestsCache, RequestGroupsCache } from './database/cache'
 import { resolvers } from './graphql/resolvers'
 import { typeDefs } from './graphql/schema'
 
@@ -25,6 +26,7 @@ const PORT = process.env.PORT
 connectDB(() => {
   if (CACHING) {
     RequestsCache.init()
+    RequestGroupsCache.init()
   }
 })
 
@@ -36,7 +38,8 @@ const server = new ApolloServer({
   typeDefs,
   resolvers,
   dataSources: () => ({
-    requests: new RequestDataSource()
+    requests: new RequestGroupDataSource(),
+    requestGroups: new RequestGroupDataSource(),
   })
 })
 


### PR DESCRIPTION
+ Contributes to issue #14 
+ Adds graphql endpoint for `RequestGroup`s
+ Adds caching for `RequestGroup`s
+ Note: Cannot get array of `RequestType`s in a `RequestGroup` yet
  + datasource for `RequestType`s will be added in a separate PR
