### PR TITLE
fixed client resolver, modified clientId -> client to fit with naming of requestTypes/requests under requestGroup/requestType

### DIFF
--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -28,7 +28,7 @@ const resolvers = {
     deleted: (parent, __, { dataSources }): Array<RequestInterface> => parent.deleted.map(id => dataSources.requests.getById(Types.ObjectId(id)))
   },
   Request: {
-    clientId: (parent, __, { dataSources }): Array<ClientInterface> => parent.open.map(id => dataSources.clients.getById(Types.ObjectId(id)))
+    client: (parent, __, { dataSources }): ClientInterface => dataSources.clients.getById(Types.ObjectId(parent.client))
   }
 }
 

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -12,7 +12,7 @@ const typeDefs = gql`
     type Request {
         _id: ID
         requestId: String
-        clientId: ID
+        client: Client
         dateUpdated: String
         dateCreated: String
         dateFulfilled: String

--- a/server/models/requestModel.ts
+++ b/server/models/requestModel.ts
@@ -3,7 +3,7 @@ import { Document, model, Schema, Types } from 'mongoose'
 interface RequestInterface {
   _id: Types.ObjectId
   requestId: string
-  clientId: Types.ObjectId
+  client: Types.ObjectId
   dateUpdated: Date
   dateCreated: Date
   dateFulfilled: Date
@@ -18,7 +18,7 @@ const requestSchema = new Schema({
     type: String,
     required: true
   },
-  clientId: {
+  client: {
     type: Types.ObjectId, ref: 'Client'
   },
   dateUpdated: {

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -90,7 +90,7 @@ connectDB(() => {
         const request = new Request({
           _id: mongoose.Types.ObjectId(),
           requestId: faker.random.alphaNumeric(6),
-          clientId: faker.random.arrayElement(clientIDs)
+          client: faker.random.arrayElement(clientIDs)
         })
         requestIDs.push(request._id) // store IDs to allocate among groups + types
         const promise = request.save().catch((err) => {


### PR DESCRIPTION
"clientId" under Request schema is now "client"

Resolver now working
Seeder updated to match this
![image](https://user-images.githubusercontent.com/32274856/109585560-bcd8a400-7ad1-11eb-9b64-edcf34e0a96c.png)

