### PR TITLE
Update spacing on homepage banner

### DIFF
--- a/client/src/components/organisms/HomepageBanner.tsx
+++ b/client/src/components/organisms/HomepageBanner.tsx
@@ -33,7 +33,7 @@ const HomepageBanner: FunctionComponent = () => {
           </Col>
         </Row>
       </Col>
-      <Col md={5}>
+      <Col className="homepage-banner-image-container" md={5}>
         <img className="homepage-banner-image" src={BannerPicture} />
       </Col>
     </Row>

--- a/client/src/components/organisms/style/HomepageBanner.scss
+++ b/client/src/components/organisms/style/HomepageBanner.scss
@@ -14,6 +14,7 @@
 
   &-info {
     padding-left: 80px;
+    margin: 0 auto;
 
     & h1 {
       font-weight: bold;
@@ -49,6 +50,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
+    padding: 0;
 
     & img {
       margin-bottom: 12px;
@@ -61,5 +63,9 @@
 
   &-image {
     width: 100%;
+  }
+
+  &-image-container {
+    margin-right: auto;
   }
 }


### PR DESCRIPTION
- Change homepage banner to be centered with some space in between the stats and image
- Left aligned icons