### PR TITLE
Add email confirmed modal UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 import React from "react";
 
 import ConfirmationModal from "./pages/ConfirmationModal";
+import EmailConfirmedModal from './pages/EmailConfirmedModal';
 import RequestGroupDonorView from './components/organisms/RequestGroupDonorView';
 import SampleContainer from "./components/examples/SampleContainer";
 import SignUpModal from './pages/SignUpModal';
@@ -16,6 +17,7 @@ function App(): JSX.Element {
         {/* TODO(jlight99): delete /confirmation endpoint after logic for triggering the confirmation modal upon signup has been added */}
         <Route path='/confirmation' component={() => <ConfirmationModal email="anna@pregnancycentre.ca"/>}></Route>
         <Route path='/signup' strict component={SignUpModal}></Route>
+        <Route path='/email-confirmed' strict component={EmailConfirmedModal}></Route>
         <Route path='/test'>
           <RequestGroupDonorView requestGroupId="603d9b41eb57fc06447b8a23"/>
         </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,7 @@ function App(): JSX.Element {
         {/* TODO(jlight99): delete /confirmation endpoint after logic for triggering the confirmation modal upon signup has been added */}
         <Route path='/confirmation' component={() => <ConfirmationModal email="anna@pregnancycentre.ca"/>}></Route>
         <Route path='/signup' strict component={SignUpModal}></Route>
+        {/* TODO(jlight99): delete /email-confirmed endpoint after logic for triggering the email confirmed modal has been added */}
         <Route path='/email-confirmed' strict component={EmailConfirmedModal}></Route>
         <Route path='/test'>
           <RequestGroupDonorView requestGroupId="603d9b41eb57fc06447b8a23"/>

--- a/client/src/components/organisms/Modal.tsx
+++ b/client/src/components/organisms/Modal.tsx
@@ -8,7 +8,7 @@ interface Props {
   title: string;
   show: boolean;
   handleClose(): void;
-  body: React.ReactElement<any>;
+  body: React.ReactNode;
 }
 
 const CommonModal: FunctionComponent<Props> = (props: Props) => {

--- a/client/src/pages/EmailConfirmedModal.tsx
+++ b/client/src/pages/EmailConfirmedModal.tsx
@@ -1,0 +1,26 @@
+import '../components/organisms/style/Modal.scss';
+import React, { FunctionComponent, useState } from 'react';
+import CommonModal from '../components/organisms/Modal';
+
+const EmailConfirmedModal: FunctionComponent = () => {
+  const [show, setShow] = useState(true);
+
+  const handleClose = () => setShow(false);
+
+  return (
+    <CommonModal show={show} title={"Email Confirmed"} handleClose={handleClose} body={
+      <span>
+        <div className="text">
+          Your account has now been made. 
+        <div className="text">
+          You can now log into your account with the button below or close this  window.        </div>
+        </div>
+        <button className="button" onClick={handleClose}>
+          Log in
+        </button>
+      </span>
+    }></CommonModal>
+  );
+}
+
+export default EmailConfirmedModal;


### PR DESCRIPTION
This PR is part of the admin signup flow (ticket: #15).

It adds the email confirmed modal UI, and fixes the CircleCI error by changing the modal body type from `React.ReactElement<any> -> React.ReactNode`.

This can be tested by navigating to /email-confirmed.
A screenshot is attached below:

![email-confirmed](https://user-images.githubusercontent.com/33968239/111081595-6a888180-84da-11eb-9aca-166f3620852f.png)
