### PR TITLE
Display email confirmed modal upon valid oobcode in URL

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import "./App.scss";
 import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 import React from "react";
 
+import AuthTestComponent from './pages/AuthTestComponent';
 import ConfirmationModal from "./pages/ConfirmationModal";
 import EmailConfirmedModal from './pages/EmailConfirmedModal';
 import RequestGroupDonorView from './components/organisms/RequestGroupDonorView';
@@ -19,6 +20,7 @@ function App(): JSX.Element {
         <Route path='/signup' strict component={SignUpModal}></Route>
         {/* TODO(jlight99): delete /email-confirmed endpoint after logic for triggering the email confirmed modal has been added */}
         <Route path='/email-confirmed' strict component={EmailConfirmedModal}></Route>
+        <Route path='/verify-email' component={AuthTestComponent}></Route>
         <Route path='/test'>
           <RequestGroupDonorView requestGroupId="603d9b41eb57fc06447b8a23"/>
         </Route>

--- a/client/src/pages/AuthTestComponent.tsx
+++ b/client/src/pages/AuthTestComponent.tsx
@@ -15,7 +15,7 @@ const AuthTestComponent: FunctionComponent = () => {
         handleVerifyEmail(actionCode)
           .then((err: string) => {
             setConfirmationErrors(err);
-            if (err === "") {
+            if (!err) {
               setShowEmailConfirmedModal(true);
             }
           })

--- a/client/src/pages/AuthTestComponent.tsx
+++ b/client/src/pages/AuthTestComponent.tsx
@@ -1,0 +1,42 @@
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import EmailConfirmedModal from '../pages/EmailConfirmedModal';
+import { handleVerifyEmail } from '../services/auth';
+
+const AuthTestComponent: FunctionComponent = () => {
+  // confirmationErrors is currently not being used, but will be used when we create error modals in later iterations
+  const [confirmationErrors, setConfirmationErrors] = useState('');
+  const [showEmailConfirmedModal, setShowEmailConfirmedModal] = useState(false);
+
+  useEffect(() => {
+    async function verifyEmail() {
+      const URLParams = new URLSearchParams(window.location.href);
+      const actionCode = URLParams.get("oobCode");
+      if (actionCode) {
+        handleVerifyEmail(actionCode)
+          .then((err: string) => {
+            setConfirmationErrors(err);
+            if (err === "") {
+              setShowEmailConfirmedModal(true);
+            }
+          })
+          .catch((err: string) => {
+            setConfirmationErrors(err);
+          });
+      }
+    }
+    verifyEmail();
+  }, []); 
+
+  return (
+    <div>
+      {showEmailConfirmedModal && 
+        <EmailConfirmedModal></EmailConfirmedModal>
+      }
+      {(confirmationErrors !== '') && 
+        <span>your email has not been confirmed</span>
+      }
+    </div>
+  );
+}
+
+export default AuthTestComponent;

--- a/client/src/pages/ConfirmationModal.tsx
+++ b/client/src/pages/ConfirmationModal.tsx
@@ -1,4 +1,3 @@
-import '../components/organisms/style/Modal.scss';
 import React, { FunctionComponent, useState } from 'react';
 import CommonModal from '../components/organisms/Modal';
 

--- a/client/src/pages/EmailConfirmedModal.tsx
+++ b/client/src/pages/EmailConfirmedModal.tsx
@@ -1,4 +1,3 @@
-import '../components/organisms/style/Modal.scss';
 import React, { FunctionComponent, useState } from 'react';
 import CommonModal from '../components/organisms/Modal';
 

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -60,7 +60,7 @@ export const handleVerifyEmail = async (
   const error = await firebase
     .auth()
     .applyActionCode(actionCode)
-    .then((resp: any) => {
+    .then(() => {
       return "";
     })
     .catch((err) => {


### PR DESCRIPTION
This PR is part of the auth sign up flow (#15)

Adding a dummy component `AuthTestComponent` which is rendered when navigating to /verify-email.
The flow is:
1. the user signs up via the sign up modal (SignUpModal.tsx)
2. the user sees the email confirmation modal (ConfirmationModal.tsx)
3. the user goes to their email, opens the confirmation email from Firebase, and clicks on the confirmation link
4. the confirmation link will take them to the /verify-email?mode=action&oobCode=code in our app
5. if the `oobCode` is valid, the email confirmed modal is displayed, otherwise a temporary error message is displayed (in the future, we would display an error modal)

Thanks for working together with me on this @chamod-gamage!