### PR TITLE
Add password reset email sent modal

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16790,6 +16790,7 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -16807,6 +16808,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -16837,6 +16839,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -16848,6 +16851,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -16898,6 +16902,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -16906,6 +16911,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -16916,6 +16922,7 @@
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -16971,6 +16978,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "optional": true,
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,6 +24,7 @@ function App(): JSX.Element {
         <Route path='/signup' strict component={SignUpModal}></Route>
         {/* TODO(jlight99): delete /email-confirmed endpoint after logic for triggering the email confirmed modal has been added */}
         <Route path='/email-confirmed' strict component={EmailConfirmedModal}></Route>
+        <Route path='/password-reset-email-sent' strict component={PasswordResetEmailSentModal}></Route>
         <Route path='/test'>
           <RequestGroupDonorView requestGroupId="603d9b41eb57fc06447b8a23"/>
         </Route>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import ConfirmationModal from "./pages/ConfirmationModal";
 import DonorRequestGroupBrowser from './components/organisms/DonorRequestGroupBrowser'
 import EmailConfirmedModal from './pages/EmailConfirmedModal';
+import PasswordResetEmailSentModal from "./pages/PasswordResetEmailSentModal";
 import RequestGroupDonorView from './components/organisms/RequestGroupDonorView';
 import SampleContainer from "./components/examples/SampleContainer";
 import SignUpModal from "./pages/SignUpModal";

--- a/client/src/pages/PasswordResetEmailSentModal.tsx
+++ b/client/src/pages/PasswordResetEmailSentModal.tsx
@@ -8,15 +8,15 @@ const EmailConfirmedModal: FunctionComponent = () => {
   const handleClose = () => setShow(false);
 
   return (
-    <CommonModal show={show} title={"Email Confirmed"} subtitle={''} handleClose={handleClose} body={
+    <CommonModal show={show} title={"Email Sent"} subtitle={''} handleClose={handleClose} body={
       <span>
         <div className="text">
-          Your account has now been made. 
+            Check your email and click on the password reset link to reset the password to your account.
         <div className="text">
-          You can now log into your account with the button below or close this  window.        </div>
+            The link will expire after X days, after which you’ll have to request another reset link.</div>
         </div>
         <button className="button" onClick={handleClose}>
-          Log in
+          I understand
         </button>
       </span>
     }></CommonModal>

--- a/client/src/pages/PasswordResetEmailSentModal.tsx
+++ b/client/src/pages/PasswordResetEmailSentModal.tsx
@@ -12,8 +12,9 @@ const EmailConfirmedModal: FunctionComponent = () => {
       <span>
         <div className="text">
             Check your email and click on the password reset link to reset the password to your account.
-        <div className="text">
-            The link will expire after X days, after which you’ll have to request another reset link.</div>
+            <div className="text">
+                The link will expire after X days, after which you’ll have to request another reset link.
+            </div>
         </div>
         <button className="button" onClick={handleClose}>
           I understand

--- a/client/src/pages/PasswordResetEmailSentModal.tsx
+++ b/client/src/pages/PasswordResetEmailSentModal.tsx
@@ -1,0 +1,26 @@
+import '../components/organisms/style/Modal.scss';
+import React, { FunctionComponent, useState } from 'react';
+import CommonModal from '../components/organisms/Modal';
+
+const EmailConfirmedModal: FunctionComponent = () => {
+  const [show, setShow] = useState(true);
+
+  const handleClose = () => setShow(false);
+
+  return (
+    <CommonModal show={show} title={"Email Confirmed"} subtitle={''} handleClose={handleClose} body={
+      <span>
+        <div className="text">
+          Your account has now been made. 
+        <div className="text">
+          You can now log into your account with the button below or close this  window.        </div>
+        </div>
+        <button className="button" onClick={handleClose}>
+          Log in
+        </button>
+      </span>
+    }></CommonModal>
+  );
+}
+
+export default EmailConfirmedModal;


### PR DESCRIPTION
This PR's part of the auth password reset flow!
- **What I did:** Created a new file indicating a sent email based off of the email confirmed screen and added a route for it
- **Link**: [http://localhost:3000/password-reset-email-sent](url)

![image](https://user-images.githubusercontent.com/57274622/111411194-79289180-86b0-11eb-875a-09132442bedf.png)
