### PR TITLE
Add basic functionality for create/update/delete on requestGroups

### DIFF
--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -17,6 +17,9 @@ const resolvers = {
     requestGroups: (_, __, { dataSources }): Array<RequestGroupInterface> => dataSources.requestGroups.getAll()
   },
   Mutation: {
+    createRequestGroup: (_, { requestGroup }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requestGroups.create(requestGroup),
+    updateRequestGroup: (_, { requestGroup }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requestGroups.update(requestGroup),
+    softDeleteRequestGroup: (_, { id }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requestGroups.softDelete(id),
     createRequestType: (_, { requestType }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requestTypes.create(requestType),
     updateRequestType: (_, { requestType }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requestTypes.update(requestType),
     softDeleteRequestType: (_, { id }, { dataSources}): Promise<ServerResponseInterface> => dataSources.requestTypes.softDelete(id),

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -59,6 +59,9 @@ const typeDefs = gql`
         requestGroups: [RequestGroup]
     }
     type Mutation {
+        createRequestGroup(requestGroup: RequestGroupInput): ServerResponse
+        updateRequestGroup(requestGroup: RequestGroupInput): ServerResponse
+        softDeleteRequestGroup(id: ID): ServerResponse
         createRequestType(requestType: RequestTypeInput): ServerResponse
         updateRequestType(requestType: RequestTypeInput): ServerResponse
         softDeleteRequestType(id: ID): ServerResponse
@@ -70,6 +73,15 @@ const typeDefs = gql`
         open: [ID]
         fulfilled: [ID]
         deleted: [ID]
+    }
+    input RequestGroupInput {
+        id: ID
+        name: String
+        deleted: Boolean
+        description: String
+        requirements: String
+        image: String
+        requestTypes: [ID]
     }
     input RequestTypeInput {
         id: ID

--- a/server/models/requestGroupModel.ts
+++ b/server/models/requestGroupModel.ts
@@ -39,7 +39,8 @@ const RequestGroupSchema = new Schema({
     type: String
   },
   requestTypes: {
-    type: [ { type: Types.ObjectId, ref: 'RequestType' } ]
+    type: [ { type: Types.ObjectId, ref: 'RequestType' } ],
+    default: []
   }
 })
 


### PR DESCRIPTION
- Basically the same stuff that was added for requestTypes
- The handling of the arrays will be done in a different PR
- The handling of the backwards resolver fields (eg request.requestType, requestType.requestGroup) will be handled in a different PR once backward resolvers are added