### PR TITLE
created resolvers for client

### DIFF
--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -25,7 +25,10 @@ const resolvers = {
     softDeleteRequestType: (_, { id }, { dataSources}): Promise<ServerResponseInterface> => dataSources.requestTypes.softDelete(id),
     createRequest: (_, { request }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requests.create(request),
     updateRequest: (_, { request }, { dataSources }): Promise<ServerResponseInterface> => dataSources.requests.update(request),
-    softDeleteRequest: (_, { id }, { dataSources}): Promise<ServerResponseInterface> => dataSources.requests.softDelete(id)
+    softDeleteRequest: (_, { id }, { dataSources}): Promise<ServerResponseInterface> => dataSources.requests.softDelete(id),
+    createClient: (_, { client }, { dataSources }): Promise<ServerResponseInterface> => dataSources.clients.create(client),
+    updateClient: (_, { client }, { dataSources }): Promise<ServerResponseInterface> => dataSources.clients.update(client),
+    softDeleteClient: (_, { id }, { dataSources}): Promise<ServerResponseInterface> => dataSources.clients.softDelete(id)
   },
   RequestGroup: {
     numOpen: (parent, __, { dataSources }): Number => parent.requestTypes.map(id => dataSources.requestTypes.getById(Types.ObjectId(id)).requests.open.length).reduce((total, num) => total + num),

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -8,6 +8,7 @@ const typeDefs = gql`
         clientId: String
         firstName: String
         lastName: String
+        deleted: Boolean
     }
     type Request {
         _id: ID
@@ -68,6 +69,9 @@ const typeDefs = gql`
         createRequest(request: RequestInput): ServerResponse
         updateRequest(request: RequestInput): ServerResponse
         softDeleteRequest(id: ID): ServerResponse
+        createClient(client: ClientInput): ServerResponse
+        updateClient(client: ClientInput): ServerResponse
+        softDeleteClient(id: ID): ServerResponse
     }
     input RequestListingInput {
         open: [ID]
@@ -90,10 +94,17 @@ const typeDefs = gql`
         requests: RequestListingInput
     }
     input RequestInput {
+        id: ID
         client: ID
         requestId: String
         deleted: Boolean
         fulfilled: Boolean
+    }
+    input ClientInput {
+        id: ID
+        clientId: String
+        firstName: String
+        lastName: String
     }
 `
 

--- a/server/models/clientModel.ts
+++ b/server/models/clientModel.ts
@@ -5,6 +5,7 @@ interface ClientInterface {
   clientId: string
   firstName: string
   lastName: string
+  deleted: boolean
 }
 
 type ClientDocument = ClientInterface & Document;
@@ -23,6 +24,11 @@ const ClientSchema = new Schema({
     type: String,
     required: true,
     trim: true
+  },
+  deleted: {
+    type: Boolean,
+    required: true,
+    default: false
   }
 })
 


### PR DESCRIPTION
What's new
- created create, update, soft delete resolvers for client
- added deleted field to client

How to test PR
- Run server and go to localhost:4000
- Run create, update, delete mutations (see screenshots) and verify the appropriate responses are there

<img width="1125" alt="create" src="https://user-images.githubusercontent.com/42297577/111531919-8343a200-873b-11eb-93c3-0df8776fe4ba.png">
<img width="1114" alt="update" src="https://user-images.githubusercontent.com/42297577/111531920-8343a200-873b-11eb-88bd-a72ffb9ef58d.png">
<img width="1144" alt="delete" src="https://user-images.githubusercontent.com/42297577/111531921-83dc3880-873b-11eb-987f-e92743ba966d.png">
