### PR TITLE
Fix spacing requestgroupdonorview

### DIFF
--- a/client/src/components/atoms/style/RequestTypeListItem.scss
+++ b/client/src/components/atoms/style/RequestTypeListItem.scss
@@ -1,5 +1,9 @@
 .request-type-list-item {
     border-bottom: $border-line;
+    &.list-group-item, &.list-group-item:last-child { // overwrite React Bootstrap styling
+        border-bottom: $border-line;
+    }
+
     padding: 16px 0px;
     line-height: 20px;
 

--- a/client/src/components/layouts/style/DonorPage.scss
+++ b/client/src/components/layouts/style/DonorPage.scss
@@ -6,4 +6,5 @@
 
 .donor-page-content {
   flex-grow: 1;
+  overflow-x: hidden;
 }

--- a/client/src/components/molecules/style/InfoBox.scss
+++ b/client/src/components/molecules/style/InfoBox.scss
@@ -2,7 +2,6 @@
     border: $border-line;
     box-sizing: border-box;
     border-radius: $box-border-radius;
-    width: 331px;
     height: 100%;
 
     .card-body {

--- a/client/src/components/molecules/style/InfoBox.scss
+++ b/client/src/components/molecules/style/InfoBox.scss
@@ -2,6 +2,7 @@
     border: $border-line;
     box-sizing: border-box;
     border-radius: $box-border-radius;
+    width: 100%;
     height: 100%;
 
     .card-body {

--- a/client/src/components/molecules/style/RequestTypeList.scss
+++ b/client/src/components/molecules/style/RequestTypeList.scss
@@ -6,5 +6,5 @@
         margin: 0;
     }
 
-    width: 514px;
+    width: 100%;
 }

--- a/client/src/components/organisms/DonorRequestGroupBrowser.tsx
+++ b/client/src/components/organisms/DonorRequestGroupBrowser.tsx
@@ -1,7 +1,6 @@
 import { bindActionCreators, Dispatch } from "redux"
 import { gql, useQuery } from "@apollo/client";
 import React, { FunctionComponent, useState } from "react";
-import Col from 'react-bootstrap/Col'
 import { connect } from "react-redux";
 import Container from 'react-bootstrap/Container'
 import Row from 'react-bootstrap/Row'
@@ -65,16 +64,16 @@ const DonorRequestGroupBrowser: FunctionComponent<Props> = (props: React.PropsWi
     <Row className="justify-content-center">
       <h1 className="donor-request-group-browser-header">Open Requests</h1>
     </Row>
-    <Row className="justify-content-start donor-request-group-browser-content">
-      <Col className="donor-request-group-browser-list" md={4}>
+    <Row className="justify-content-center donor-request-group-browser-content">
+      <div className="donor-request-group-browser-list">
         <RequestGroupList
           selectedRequestGroup={selectedRequestGroup}
           onRequestGroupChange={(requestGroupdId: string) => { setSelectedRequestGroup(requestGroupdId) }}
         />
-      </Col>
-      <Col className="donor-request-group-browser-indiv-view" md={8}>
+      </div>
+      <div className="donor-request-group-browser-indiv-view">
         <RequestGroupDonorView requestGroupId={selectedRequestGroup}/>
-      </Col>
+      </div>
     </Row>
   </Container>
 };

--- a/client/src/components/organisms/DonorRequestGroupBrowser.tsx
+++ b/client/src/components/organisms/DonorRequestGroupBrowser.tsx
@@ -62,7 +62,9 @@ const DonorRequestGroupBrowser: FunctionComponent<Props> = (props: React.PropsWi
 
 
   return <Container className="donor-request-group-browser" fluid>
-    <Row className="justify-content-center"><h1 className="donor-request-group-browser-header">Open Requests</h1></Row>
+    <Row className="justify-content-center">
+      <h1 className="donor-request-group-browser-header">Open Requests</h1>
+    </Row>
     <Row className="justify-content-start donor-request-group-browser-content">
       <Col className="donor-request-group-browser-list" md={4}>
         <RequestGroupList

--- a/client/src/components/organisms/DonorRequestGroupBrowser.tsx
+++ b/client/src/components/organisms/DonorRequestGroupBrowser.tsx
@@ -70,7 +70,9 @@ const DonorRequestGroupBrowser: FunctionComponent<Props> = (props: React.PropsWi
           onRequestGroupChange={(requestGroupdId: string) => { setSelectedRequestGroup(requestGroupdId) }}
         />
       </Col>
-      <Col className="donor-request-group-browser-indiv-view" md={8}><RequestGroupDonorView requestGroupId={selectedRequestGroup}/></Col>
+      <Col className="donor-request-group-browser-indiv-view" md={8}>
+        <RequestGroupDonorView requestGroupId={selectedRequestGroup}/>
+      </Col>
     </Row>
   </Container>
 };

--- a/client/src/components/organisms/RequestGroupDonorView.tsx
+++ b/client/src/components/organisms/RequestGroupDonorView.tsx
@@ -2,7 +2,7 @@ import { gql, useQuery } from "@apollo/client";
 import React, { FunctionComponent, useState } from 'react';
 import moment from 'moment';
 
-import { Spinner } from 'react-bootstrap';
+import { Col, Row, Spinner } from 'react-bootstrap';
 
 import InfoBox from '../molecules/InfoBox';
 import RequestGroup from '../../data/types/requestGroup';
@@ -45,7 +45,7 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
     });
 
     return (
-        <div className="request-group-view">
+        <Row className="request-group-view">
             {requestGroupData === undefined
             ?
             <div className="spinner"> 
@@ -53,7 +53,7 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
             </div>
             :
             <div className="panel">
-                <div className="section" id="left">
+                <Col className="section" id="left" md={7} sm={12}>
                     <div className="info">
                         <h1 id="header">
                             {requestGroupData.name}
@@ -66,8 +66,8 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
                         </div>
                     </div>
                     <RequestTypeList requestTypes={requestGroupData.requestTypes ? requestGroupData.requestTypes : []}/>
-                </div>
-                <div className="section" id="right">
+                </Col>
+                <Col className="section" id="right" md={5} sm={12}>
                     <InfoBox 
                         title="HAVE A DONATION?" 
                         text="To arrange your donation, contact the Pregnancy Center directly at 514‑999‑9999 or send an email."
@@ -95,9 +95,9 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
                             text={requestGroupData.description ? requestGroupData.description : ''}
                         />
                     </div>
-                </div>
+                </Col>
             </div>}
-        </div>
+        </Row>
     )
 }
 

--- a/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
+++ b/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
@@ -1,4 +1,6 @@
 .donor-request-group-browser {
+  padding-bottom: 33px;
+
   &-header {
     font-weight: bold;
     font-size: 28px;

--- a/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
+++ b/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
@@ -11,4 +11,10 @@
   &-list {
     border-right: $border-line;
   }
+
+  .donor-request-group-browser-indiv-view {
+    padding: 0;
+    padding-top: 27px;
+    padding-left: 32px;
+  }
 }

--- a/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
+++ b/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
@@ -14,7 +14,5 @@
 
   .donor-request-group-browser-indiv-view {
     padding: 0;
-    padding-top: 27px;
-    padding-left: 32px;
   }
 }

--- a/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
+++ b/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
@@ -1,5 +1,5 @@
 .donor-request-group-browser {
-  padding-bottom: 33px;
+  padding-bottom: 35px;
 
   &-header {
     font-weight: bold;
@@ -12,6 +12,7 @@
   }
   &-list {
     border-right: $border-line;
+    padding-right: 32px;
   }
   
   .donor-request-group-browser-header {

--- a/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
+++ b/client/src/components/organisms/style/DonorRequestGroupBrowser.scss
@@ -13,6 +13,10 @@
   &-list {
     border-right: $border-line;
   }
+  
+  .donor-request-group-browser-header {
+    margin-bottom: 0;
+  }
 
   .donor-request-group-browser-indiv-view {
     padding: 0;

--- a/client/src/components/organisms/style/Footer.scss
+++ b/client/src/components/organisms/style/Footer.scss
@@ -1,8 +1,10 @@
 $footer-lr-padding: 0 20px;
 
 .footer.container-fluid {
-  padding-left: 70px;
-  padding-right: 55px;
+  @media (min-width: 992px) {
+    padding-left: 70px;
+    padding-right: 55px;
+  }
 
   background-color: $selected-item-background;
   height: 338px;
@@ -14,6 +16,9 @@ $footer-lr-padding: 0 20px;
 
   border-top: $border-line;
   margin-top: 62px;
+  @media (max-width: 992px) {
+    margin-top: 16px;
+  }
   padding: $footer-lr-padding;
   padding-top: 22px;
 
@@ -36,6 +41,9 @@ $footer-lr-padding: 0 20px;
 
   padding: $footer-lr-padding;
   padding-top: 74px;
+  @media (max-width: 862px) {
+    padding-top: 32px;
+  }
 
   & h1 {
     @include faded-text;
@@ -57,12 +65,43 @@ $footer-lr-padding: 0 20px;
     flex-grow: 0;
     flex-basis: unset;
     padding: 0;
+    width: auto;
     margin: 0;
     margin-right: 90px;
-    width: auto;
+    @media (max-width: 1166px) {
+      margin-right: 32px;
+    }
+    @media (max-width: 992px) {
+      margin-right: 12px;
+    }
+    @media (max-width: 860px) {
+      margin-right: 32px;
+      padding-left: 6px;
+    }
   }
 
   &.row div[class^="col"]:first-child {
     margin-right: 84px;
+    @media (max-width: 992px) {
+      margin-right: 32px;
+    }
+    @media (max-width: 860px) {
+      margin-right: 78px;
+    }
+  }
+
+  &.row div[class^="col"]:last-child {
+    @media (max-width: 1256px) {
+      margin-right: 0px;
+    }
+    @media (max-width: 992px) {
+      margin-left: 0px;
+    }
+    @media (max-width: 862px) {
+      margin-left: 258px;
+    }
+    @media (max-width: 748px) {
+      margin-left: 60px;
+    }
   }
 }

--- a/client/src/components/organisms/style/Footer.scss
+++ b/client/src/components/organisms/style/Footer.scss
@@ -1,7 +1,7 @@
 $footer-lr-padding: 0 20px;
 
 .footer.container-fluid {
-  padding-left: 55px;
+  padding-left: 70px;
   padding-right: 55px;
 
   background-color: $selected-item-background;
@@ -13,9 +13,9 @@ $footer-lr-padding: 0 20px;
   align-items: center;
 
   border-top: $border-line;
-  margin-top: 65px;
+  margin-top: 62px;
   padding: $footer-lr-padding;
-  padding-top: 27px;
+  padding-top: 22px;
 
   & h1 {
     @include normal-text;
@@ -40,6 +40,8 @@ $footer-lr-padding: 0 20px;
   & h1 {
     @include faded-text;
     @include heavy-text;
+    padding-top: 7px;
+    padding-bottom: 2px;
     font-size: 14px;
     line-height: 17px;
     letter-spacing: 0.05em;
@@ -58,5 +60,9 @@ $footer-lr-padding: 0 20px;
     margin: 0;
     margin-right: 90px;
     width: auto;
+  }
+
+  &.row div[class^="col"]:first-child {
+    margin-right: 84px;
   }
 }

--- a/client/src/components/organisms/style/Footer.scss
+++ b/client/src/components/organisms/style/Footer.scss
@@ -71,7 +71,7 @@ $footer-lr-padding: 0 20px;
     @media (max-width: 1166px) {
       margin-right: 32px;
     }
-    @media (max-width: 992px) {
+    @media (max-width: 1066px) {
       margin-right: 12px;
     }
     @media (max-width: 860px) {
@@ -82,7 +82,7 @@ $footer-lr-padding: 0 20px;
 
   &.row div[class^="col"]:first-child {
     margin-right: 84px;
-    @media (max-width: 992px) {
+    @media (max-width: 1066px) {
       margin-right: 32px;
     }
     @media (max-width: 860px) {

--- a/client/src/components/organisms/style/Navbar.scss
+++ b/client/src/components/organisms/style/Navbar.scss
@@ -1,6 +1,9 @@
 .navbar {
   height: 156px;
   padding-left: 80px;
+  @media (max-width: 992px) {
+    padding-left: 50px;
+  }
   padding-right: 45px;
   display: flex;
   justify-content: space-between;

--- a/client/src/components/organisms/style/RequestGroupDonorView.scss
+++ b/client/src/components/organisms/style/RequestGroupDonorView.scss
@@ -2,6 +2,7 @@
     align-items: center;
     justify-content: center;
     width: 100%;
+    max-width: 908px;
     padding-left: 32px;
 
     .spinner {
@@ -23,12 +24,21 @@
             float: left;
             width: 100%;
             padding-right: 16px;
+
+            .request-type-list {
+                max-width: 514px;
+            }
         }
         &#right {
             padding-top: 27px;
             float: right;
             width: 100%;
             padding-left: 16px;
+
+            .infoBox {
+                margin: 0 auto;
+                max-width: 331px;
+            }
         }
     }
 
@@ -48,7 +58,7 @@
 
     #image {
         padding: 16px 0px 24px;
-        // width: 513px;
+        max-width: 513px;
         height: 365px;
         border-radius: $box-border-radius;
         overflow: hidden;

--- a/client/src/components/organisms/style/RequestGroupDonorView.scss
+++ b/client/src/components/organisms/style/RequestGroupDonorView.scss
@@ -2,7 +2,6 @@
     align-items: center;
     justify-content: center;
     width: 100%;
-    padding-right: 94px;
     padding-left: 32px;
 
     .spinner {
@@ -22,13 +21,13 @@
         &#left {
             padding-top: 27px;
             float: left;
-            width: 514px;
+            width: 100%;
             padding-right: 16px;
         }
         &#right {
             padding-top: 27px;
             float: right;
-            width: 331px;
+            width: 100%;
             padding-left: 16px;
         }
     }
@@ -49,7 +48,7 @@
 
     #image {
         padding: 16px 0px 24px;
-        width: 513px;
+        // width: 513px;
         height: 365px;
         border-radius: $box-border-radius;
         overflow: hidden;
@@ -64,6 +63,7 @@
     #description {
         padding-top: 20px;
         height: 468px;
+        width: 100%;
 
         .card-text {
             padding-top: 8px;

--- a/client/src/components/organisms/style/RequestGroupDonorView.scss
+++ b/client/src/components/organisms/style/RequestGroupDonorView.scss
@@ -2,7 +2,8 @@
     align-items: center;
     justify-content: center;
     width: 100%;
-    height: 714px;
+    padding-right: 94px;
+    padding-left: 32px;
 
     .spinner {
         position: relative;
@@ -12,17 +13,20 @@
     }
 
     .panel {
-        display: table;
+        display: block;
+        align-items: center;
         width: 100%;
     }
 
     .section {
         &#left {
+            padding-top: 27px;
             float: left;
             width: 514px;
             padding-right: 16px;
         }
         &#right {
+            padding-top: 27px;
             float: right;
             width: 331px;
             padding-left: 16px;
@@ -59,7 +63,7 @@
 
     #description {
         padding-top: 20px;
-        height: 446px;
+        height: 468px;
 
         .card-text {
             padding-top: 8px;

--- a/client/src/components/organisms/style/RequestGroupDonorView.scss
+++ b/client/src/components/organisms/style/RequestGroupDonorView.scss
@@ -1,5 +1,4 @@
 .request-group-view {
-    display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
@@ -14,8 +13,7 @@
 
     .panel {
         display: table;
-        width: 923px;
-        padding: 32px;
+        width: 100%;
     }
 
     .section {


### PR DESCRIPTION
- RequestGroupDonorView is now responsive (but not responsive in a nice way, should be discussed with designers how it should look on smaller screens eventually) using Bootstrap Row/Col (at least it doesn't break the entire display on smaller screens atm)
- RequestGoupDonorView is now not positioned by pixel location but by relative position in its Col in DonorRequestGroupBrowser
- Fixed issue where React Bootstrap was overwriting style for bottom border for last RequestTypeListItem
- Fixed some differences in spacing between footer and Figma
- Fixed spacing with "Open Requests" header

Normal desktop screen:
![image](https://user-images.githubusercontent.com/32274856/111860345-4f27d700-891d-11eb-98be-6084d54dff2f.png)

Narrow screen:
![image](https://user-images.githubusercontent.com/32274856/111860349-564ee500-891d-11eb-9d6a-28e94e78f8c7.png)


