### PR TITLE
fixed RequestGroupDonorView not showing spinner on loading

### DIFF
--- a/client/src/components/organisms/RequestGroupDonorView.tsx
+++ b/client/src/components/organisms/RequestGroupDonorView.tsx
@@ -1,5 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
-import React, { FunctionComponent, useState } from 'react';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import moment from 'moment';
 
 import { Spinner } from 'react-bootstrap';
@@ -21,28 +21,37 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
 
     const [requestGroupData, setRequestGroupData] = useState<RequestGroup | undefined>(undefined);
 
-    const query = gql`{
-        requestGroup(id: "${props.requestGroupId}") {
-            _id
-            name
-            dateUpdated
-            description
-            requirements
-            image
-            requestTypes {
+    const query = gql`
+        query FetchRequestGroup($id: ID!) {
+            requestGroup(id: $id) {
                 _id
                 name
-                numOpen
+                dateUpdated
+                description
+                requirements
+                image
+                requestTypes {
+                    _id
+                    name
+                    numOpen
+                }
             }
-        }
-    }`;
+        }  
+    `;
 
-    useQuery(query, {
+    const { loading, error, data } = useQuery(query, {
+        variables: {id: props.requestGroupId,}, 
         onCompleted: ( data: { requestGroup: RequestGroup }) => {
             const res = JSON.parse(JSON.stringify(data.requestGroup)); // deep-copy since data object is frozen
             setRequestGroupData(res);
         }
     });
+
+    useEffect(() => {
+        if (loading || error) {
+            setRequestGroupData(undefined);
+        }
+    }, [loading, error]);
 
     return (
         <div className="request-group-view">

--- a/client/src/components/organisms/RequestGroupDonorView.tsx
+++ b/client/src/components/organisms/RequestGroupDonorView.tsx
@@ -39,7 +39,7 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
         }  
     `;
 
-    const { loading, error, data } = useQuery(query, {
+    const { loading, error } = useQuery(query, {
         variables: {id: props.requestGroupId,}, 
         onCompleted: ( data: { requestGroup: RequestGroup }) => {
             const res = JSON.parse(JSON.stringify(data.requestGroup)); // deep-copy since data object is frozen


### PR DESCRIPTION
Before, the useQuery on this component was being done incorrectly. I updated it to properly use useQuery hook and to enable the spinner when waiting for a query to be completed.