### PR TITLE
Signin firebase integration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^17.0.1",
     "@types/react-dom": "^17.0.0",
     "@types/react-redux": "^7.1.16",
+    "apollo-link-http": "^1.5.17",
     "bootstrap": "^4.6.0",
     "firebase": "^8.2.9",
     "graphql": "^15.5.0",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,6 +3,8 @@ import { ApolloClient, ApolloProvider, createHttpLink, InMemoryCache } from "@ap
 import { Provider } from "react-redux";
 import React from "react";
 import ReactDOM from "react-dom";
+import { setContext } from '@apollo/client/link/context';
+
 
 /* Imports from local files */
 import "./index.css";
@@ -11,11 +13,19 @@ import configureStore from "./data/store";
 
 const link = createHttpLink({
   uri: `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/graphql`, credentials: "include",
-  headers: { "Content-Type": "application/json" },
+});
+
+const authLink = setContext((_, { headers }) => {
+  return {
+    headers: {
+      ...headers,
+      "Content-Type": "application/graphql"
+    }
+  }
 });
 
 const apolloClient = new ApolloClient({
-  link: link,
+  link: authLink.concat(link),
   cache: new InMemoryCache({
     addTypename: false
   })

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,5 @@
 /* Imports from packages */
-import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
+import { ApolloClient, ApolloProvider, createHttpLink, InMemoryCache } from "@apollo/client";
 import { Provider } from "react-redux";
 import React from "react";
 import ReactDOM from "react-dom";
@@ -9,11 +9,16 @@ import "./index.css";
 import App from "./App";
 import configureStore from "./data/store";
 
+const link = createHttpLink({
+  uri: `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/graphql`, credentials: "include",
+  headers: { "Content-Type": "application/json" },
+});
+
 const apolloClient = new ApolloClient({
-  uri: `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/graphql`,
+  link: link,
   cache: new InMemoryCache({
     addTypename: false
-  }),
+  })
 });
 
 ReactDOM.render(

--- a/client/src/pages/Modal.scss
+++ b/client/src/pages/Modal.scss
@@ -115,6 +115,13 @@
   .input-field.error {
     border: 1px solid $input-error;
   }
+
+  .input-field.password.error {
+    border: 1px solid $input-error;
+    width: 325px;
+    display: flex;
+    flex-direction: row;
+  }
 }
 
 .modal-header {

--- a/client/src/pages/SignInModal.tsx
+++ b/client/src/pages/SignInModal.tsx
@@ -1,24 +1,31 @@
 import "./Modal.scss";
+import { EyeFilled, EyeInvisibleFilled } from "@ant-design/icons";
 import React, { FunctionComponent, useState } from "react";
 import CommonModal from "../components/organisms/Modal";
-// import { createNewAccount } from "../services/auth";
-import { EyeFilled, EyeInvisibleFilled } from "@ant-design/icons";
 import { Redirect } from "react-router-dom";
+import { signIn } from "../services/auth";
 import Spacer from "../components/atoms/Spacer";
 
 const SignInModal: FunctionComponent = () => {
+  const initialErrors = { email: "", password: "" }
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const handleClose = () => setShow(false);
-  const [errors, setErrors] = useState({ email: "", password: "" });
+  const [errors, setErrors] = useState(initialErrors);
   const [show, setShow] = useState(true);
   const [hidePassword, setHidePassword] = useState(true);
   const [redirect, setRedirect] = useState("");
 
   const handleClick = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setErrors(errors); //Change to sign in via firebase
-    setRedirect("/admin");
+    signIn(email, password).then((res) => {
+      setErrors(res)
+      if (!res.email.length && !res.password.length) {
+        setRedirect("/admin")
+      }
+    }).catch((err) => {
+      setErrors(err)
+    })
   };
 
   const onChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -45,7 +52,10 @@ const SignInModal: FunctionComponent = () => {
         <div>
           <form onSubmit={handleClick}>
             <div>
-              <div className="text signup">Email address</div>
+              <div className="row">
+                <div className="text signup">Email Address</div>
+                <div className="text error">{errors.email}</div>
+              </div>
               <input
                 name="email"
                 placeholder="Enter your company email"
@@ -56,14 +66,19 @@ const SignInModal: FunctionComponent = () => {
               />
             </div>
             <div>
-              <div className="text signup">Password</div>
+              <div className="row">
+                <div className="text signup">
+                  Password
+                </div>
+                <div className="text error">{errors.password}</div>
+              </div>
               <div className="row bordered">
                 <input
                   type={hidePassword ? "password" : "text"}
                   name="password"
                   className={
                     errors.password
-                      ? "input-field error"
+                      ? "input-field password error"
                       : "input-field password"
                   }
                   placeholder="Enter your password"
@@ -103,7 +118,7 @@ const SignInModal: FunctionComponent = () => {
               </div>
             </div>
           </form>
-        </div>
+        </div >
       }
     />
   );

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -100,13 +100,18 @@ export const signIn = async (
               .then(() => {
                 return { email: "", password: "" };
               })
-              .catch((err) => console.log(err));
+              .catch(() => ({
+                email: "Something went wrong. Please try again.",
+                password: "",
+              }));
           })
-          .catch((err) => console.log(err));
+          .catch(() => ({
+            email: "Something went wrong. Please try again.",
+            password: "",
+          }));
         return { email: "", password: "" };
       })
       .catch((error) => {
-        console.log(error);
         const code: keyof AuthErrorMessageInterface = error.code;
         return {
           email: code !== "auth/wrong-password" ? AuthErrorMessage[code] : "",
@@ -115,7 +120,6 @@ export const signIn = async (
         };
       });
   }
-  console.log(errors);
   return errors;
 };
 

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -40,9 +40,9 @@ export const createNewAccount = async (
   if (!passwordRequirements.test(password)) {
     errors.password = AuthErrorMessage["invalid-password"];
   }
-  // if (!email.endsWith("@pregnancycentre.ca")) {
-  //   errors.email = AuthErrorMessage["invalid-domain"];
-  // }
+  if (!email.endsWith("@pregnancycentre.ca")) {
+    errors.email = AuthErrorMessage["invalid-domain"];
+  }
 
   if (!errors.email.length && !errors.password.length) {
     errors = await firebase

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -92,47 +92,7 @@ export const signIn = async (
       .auth()
       .signInWithEmailAndPassword(email, password)
       .then(async () => {
-        const result = await firebase
-          .auth()
-          .currentUser?.getIdToken()
-          .then(async (token) => {
-            const res = await fetch(
-              `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/sessionLogin`,
-              {
-                method: "POST",
-                credentials: "include",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ idToken: token }),
-              }
-            )
-              .then((res) => {
-                return res?.status === 200
-                  ? { email: "", password: "" }
-                  : {
-                      email: "Something went wrong. Please try again.",
-                      password: "",
-                    };
-              })
-              .catch(() => {
-                return {
-                  email: "Something went wrong. Please try again.",
-                  password: "",
-                };
-              });
-            return res;
-          })
-          .catch(() => {
-            return {
-              email: "Something went wrong. Please try again.",
-              password: "",
-            };
-          });
-        return (
-          result || {
-            email: "Something went wrong. Please try again.",
-            password: "",
-          }
-        );
+        return await postToken();
       })
       .catch((error) => {
         const code: keyof AuthErrorMessageInterface = error.code;
@@ -145,3 +105,34 @@ export const signIn = async (
   }
   return errors;
 };
+
+async function postToken() {
+  const errors = await firebase
+    .auth()
+    .currentUser?.getIdToken()
+    .then(async (token) => {
+      const res = await fetch(
+        `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/sessionLogin`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ idToken: token }),
+        }
+      );
+
+      return res?.status === 200
+        ? { email: "", password: "" }
+        : {
+            email: "Something went wrong. Please try again.",
+            password: " ",
+          };
+    });
+
+  return (
+    errors || {
+      email: "Something went wrong. Please try again.",
+      password: " ",
+    }
+  );
+}

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -5,15 +5,23 @@ interface AuthErrorMessageInterface {
   "auth/email-already-in-use": string;
   "invalid-domain": string;
   "invalid-password": string;
+  "auth/user-not-found": string;
+  "auth/wrong-password": string;
+  "empty-email": string;
+  "empty-password": string;
 }
 
 const AuthErrorMessage: AuthErrorMessageInterface = {
-  //firebase
+  //firebase (https://firebase.google.com/docs/reference/js/firebase.auth.Auth)
   "auth/invalid-email": "Invalid email.",
   "auth/email-already-in-use": "That email has already been registered.",
+  "auth/user-not-found": "No account with this email",
+  "auth/wrong-password": "Password is incorrect",
   //pre-firebase
   "invalid-domain": "Invalid email domain.",
   "invalid-password": "Please enter a valid password.",
+  "empty-email": "Please enter your email",
+  "empty-password": "Please enter your password",
 };
 
 export const createNewAccount = async (
@@ -32,9 +40,9 @@ export const createNewAccount = async (
   if (!passwordRequirements.test(password)) {
     errors.password = AuthErrorMessage["invalid-password"];
   }
-  if (!email.endsWith("@pregnancycentre.ca")) {
-    errors.email = AuthErrorMessage["invalid-domain"];
-  }
+  // if (!email.endsWith("@pregnancycentre.ca")) {
+  //   errors.email = AuthErrorMessage["invalid-domain"];
+  // }
 
   if (!errors.email.length && !errors.password.length) {
     errors = await firebase
@@ -68,3 +76,61 @@ export const handleVerifyEmail = async (
     });
   return error;
 };
+
+export const signIn = async (
+  email: string,
+  password: string
+): Promise<{ email: string; password: string }> => {
+  let errors = { email: "", password: "" };
+  if (!email.length || !password.length) {
+    errors = {
+      email: email.length ? "" : AuthErrorMessage["empty-email"],
+      password: password.length ? "" : AuthErrorMessage["empty-password"],
+    };
+  } else {
+    errors = await firebase
+      .auth()
+      .signInWithEmailAndPassword(email, password)
+      .then(async () => {
+        console.log("logged in");
+        firebase
+          .auth()
+          .currentUser?.getIdToken()
+          .then(async (token) => {
+            console.log(token);
+            return postToken(token)
+              .then(() => {
+                return { email: "", password: "" };
+              })
+              .catch((err) => console.log(err));
+          })
+          .catch((err) => console.log(err));
+        return { email: "", password: "" };
+      })
+      .catch((error) => {
+        console.log(error);
+        const code: keyof AuthErrorMessageInterface = error.code;
+        return {
+          email: code !== "auth/wrong-password" ? AuthErrorMessage[code] : "",
+          password:
+            code === "auth/wrong-password" ? AuthErrorMessage[code] : "",
+        };
+      });
+  }
+  console.log(errors);
+  return errors;
+};
+
+async function postToken(token: string) {
+  const body = JSON.stringify({ idToken: token });
+  console.log(body);
+  return await fetch(
+    `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/sessionLogin`,
+    {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body,
+    }
+  );
+}

--- a/client/src/services/auth.ts
+++ b/client/src/services/auth.ts
@@ -92,12 +92,10 @@ export const signIn = async (
       .auth()
       .signInWithEmailAndPassword(email, password)
       .then(async () => {
-        console.log("logged in");
         firebase
           .auth()
           .currentUser?.getIdToken()
           .then(async (token) => {
-            console.log(token);
             return postToken(token)
               .then(() => {
                 return { email: "", password: "" };
@@ -123,7 +121,6 @@ export const signIn = async (
 
 async function postToken(token: string) {
   const body = JSON.stringify({ idToken: token });
-  console.log(body);
   return await fetch(
     `${process.env.REACT_APP_GRAPHQL_SERVER_URL}/sessionLogin`,
     {

--- a/server/auth/firebase.ts
+++ b/server/auth/firebase.ts
@@ -1,0 +1,39 @@
+import * as admin from "firebase-admin";
+
+admin.initializeApp({
+  credential: admin.credential.cert({
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY,
+  }),
+});
+
+export async function getUser(cookie) {
+  console.log(cookie);
+  const user = await verifyUserSessionToken(cookie);
+  return { id: user?.uid, admin: user?.admin };
+}
+
+const verifyUserSessionToken = async (token) => {
+  //Verify session cookies tokens with firebase admin.
+  //This is a low overhead operation.
+  console.log(token);
+  const user = await admin
+    .auth()
+    .verifySessionCookie(token, true /** checkRevoked */);
+  console.log(user);
+  if (user.uid) {
+    console.log(user);
+    return user;
+  } else {
+    throw new AuthError({ message: "User Session Token Verification Error" });
+  }
+};
+
+export class AuthError extends Error {
+  constructor(
+    error: { message: string; stack?: any } = { message: "Not authorized" }
+  ) {
+    super(error.message);
+  }
+}

--- a/server/auth/firebase.ts
+++ b/server/auth/firebase.ts
@@ -9,7 +9,8 @@ admin.initializeApp({
 });
 
 export async function getUser(cookie) {
-  console.log(cookie);
+  console.log("HELLLOOOOOO");
+  console.log(typeof cookie);
   const user = await verifyUserSessionToken(cookie);
   return { id: user?.uid, admin: user?.admin };
 }
@@ -17,23 +18,12 @@ export async function getUser(cookie) {
 const verifyUserSessionToken = async (token) => {
   //Verify session cookies tokens with firebase admin.
   //This is a low overhead operation.
-  console.log(token);
   const user = await admin
     .auth()
     .verifySessionCookie(token, true /** checkRevoked */);
-  console.log(user);
   if (user.uid) {
-    console.log(user);
     return user;
   } else {
-    throw new AuthError({ message: "User Session Token Verification Error" });
+    throw new Error("User Session Token Verification Error");
   }
 };
-
-export class AuthError extends Error {
-  constructor(
-    error: { message: string; stack?: any } = { message: "Not authorized" }
-  ) {
-    super(error.message);
-  }
-}

--- a/server/auth/firebase.ts
+++ b/server/auth/firebase.ts
@@ -9,8 +9,6 @@ admin.initializeApp({
 });
 
 export async function getUser(cookie) {
-  console.log("HELLLOOOOOO");
-  console.log(typeof cookie);
   const user = await verifyUserSessionToken(cookie);
   return { id: user?.uid, admin: user?.admin };
 }

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "apollo-datasource": "^0.7.3",
     "apollo-server": "^2.19.2",
     "dotenv": "^8.2.0",
+    "firebase-admin": "^9.5.0",
     "graphql": "^15.5.0",
     "mongodb": "^3.6.4",
     "mongoose": "^5.11.15",

--- a/server/package.json
+++ b/server/package.json
@@ -19,10 +19,12 @@
     "dotenv": "^8.2.0",
     "firebase-admin": "^9.5.0",
     "graphql": "^15.5.0",
+    "inflation": "^2.0.0",
     "mongodb": "^3.6.4",
     "mongoose": "^5.11.15",
     "node": "^15.7.0",
-    "nodemailer": "^6.4.17"
+    "nodemailer": "^6.4.17",
+    "raw-body": "^2.4.0"
   },
   "devDependencies": {
     "@types/mongoose": "^5.10.3",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "apollo-datasource": "^0.7.3",
     "apollo-server": "^2.19.2",
+    "body-parser": "^1.19.0",
+    "body-parser-graphql": "^1.1.0",
+    "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",
     "firebase-admin": "^9.5.0",
     "graphql": "^15.5.0",

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,14 +1,21 @@
-import { ApolloServer } from 'apollo-server'
-import { connectDB } from './database/mongoConnection'
-import dotenv from 'dotenv'
+import { ApolloServer, AuthenticationError } from "apollo-server-express";
+import { connectDB } from "./database/mongoConnection";
+import dotenv from "dotenv";
+import express from "express";
+import * as admin from "firebase-admin";
 
-import { ClientCache, RequestCache, RequestGroupCache, RequestTypeCache } from './database/cache'
-import ClientDataSource from './datasources/clientDataSource'
-import RequestDataSource from './datasources/requestDataSource'
-import RequestGroupDataSource from './datasources/requestGroupDataSource'
-import RequestTypeDataSource from './datasources/requestTypeDataSource'
-import { resolvers } from './graphql/resolvers'
-import { typeDefs } from './graphql/schema'
+import {
+  ClientCache,
+  RequestCache,
+  RequestGroupCache,
+  RequestTypeCache,
+} from "./database/cache";
+import ClientDataSource from "./datasources/clientDataSource";
+import RequestDataSource from "./datasources/requestDataSource";
+import RequestGroupDataSource from "./datasources/requestGroupDataSource";
+import RequestTypeDataSource from "./datasources/requestTypeDataSource";
+import { resolvers } from "./graphql/resolvers";
+import { typeDefs } from "./graphql/schema";
 
 // TODO: need to make script to build(compile) prod server and to run prod server
 
@@ -16,8 +23,8 @@ import { typeDefs } from './graphql/schema'
 // // APOLLO SETUP
 // //-----------------------------------------------------------------------------
 
-dotenv.config()
-const PORT = process.env.PORT
+dotenv.config();
+const PORT = process.env.PORT;
 
 // -----------------------------------------------------------------------------
 // MONGODB CONNECTION AND DATA SOURCES FOR APOLLO
@@ -25,27 +32,66 @@ const PORT = process.env.PORT
 
 // connect to MongoDB and setup data sources
 connectDB(() => {
-  ClientCache.init()
-  RequestCache.init()
-  RequestTypeCache.init()
-  RequestGroupCache.init()
-})
+  ClientCache.init();
+  RequestCache.init();
+  RequestTypeCache.init();
+  RequestGroupCache.init();
+});
 
 // -----------------------------------------------------------------------------
 // SERVER LAUNCH
 // -----------------------------------------------------------------------------
 
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-  dataSources: () => ({
-    clients: new ClientDataSource(),
-    requests: new RequestDataSource(),
-    requestTypes: new RequestTypeDataSource(),
-    requestGroups: new RequestGroupDataSource(),
-  })
-})
+const verify = async (idToken) => {
+  if (idToken) {
+    console.log(idToken);
+    var newToken = idToken.replace("Bearer ", "");
+    let header = await admin
+      .auth()
+      .verifyIdToken(newToken)
+      .then(function (decodedToken) {
+        return {
+          Authorization: "Bearer " + decodedToken,
+        };
+      })
+      .catch(function (error) {
+        console.log(error);
+        return null;
+      });
+    return header;
+  } else {
+    throw { message: "No Token" };
+  }
+};
 
-server.listen({ port: PORT }).then(({ url }) => {
-  console.log(`🚀 Server ready at ${url}`)
-})
+function gqlServer() {
+  const app = express();
+  const server = new ApolloServer({
+    typeDefs,
+    resolvers,
+    context: async ({ req, res }) => {
+      console.log(req.headers);
+      const verified = await verify(req.headers.Authorization);
+      if (!verified) throw new AuthenticationError("Authentication Error");
+      console.log("log verified", verified);
+      return {
+        headers: verified ? verified : "",
+        req,
+        res,
+      };
+    },
+    dataSources: () => ({
+      clients: new ClientDataSource(),
+      requests: new RequestDataSource(),
+      requestTypes: new RequestTypeDataSource(),
+      requestGroups: new RequestGroupDataSource(),
+    }),
+  });
+
+  server.applyMiddleware({ app, path: "/", cors: true });
+
+  return app;
+}
+
+gqlServer().listen({ port: PORT });
+console.log(`🚀 Server ready at port ${PORT}`);

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,5 +1,5 @@
-import { ApolloServer, AuthenticationError } from "apollo-server-express";
 import * as admin from "firebase-admin";
+import { ApolloServer, AuthenticationError } from "apollo-server-express";
 import bodyParser from "body-parser";
 import { connectDB } from "./database/mongoConnection";
 import cookieParser from "cookie-parser";

--- a/server/server.ts
+++ b/server/server.ts
@@ -32,6 +32,10 @@ import { typeDefs } from "./graphql/schema";
 dotenv.config();
 const PORT = process.env.PORT;
 const isProd = process.env.NODE_ENV !== "dev";
+const corsPolicy = {
+  origin: process.env.CLIENT_URL,
+  credentials: true,
+};
 
 // -----------------------------------------------------------------------------
 // MONGODB CONNECTION AND DATA SOURCES FOR APOLLO
@@ -52,13 +56,11 @@ connectDB(() => {
 async function gqlServer() {
   const app = express();
   app.use(cookieParser());
-  app.use("/sessionLogin", bodyParser.json({ strict: false, type: "*/*" }));
   app.use(
-    cors({
-      origin: "http://localhost:3000",
-      credentials: true,
-    })
+    "/sessionLogin",
+    bodyParser.json({ strict: true, type: "application/json" })
   );
+  app.use(cors(corsPolicy));
 
   //custom body parser for apolloClient GraphQL queries using CreateHTTPLink because express.json() is buggy
   app.use("/graphql", async (req, res, next) => {
@@ -130,11 +132,8 @@ async function gqlServer() {
   server.applyMiddleware({
     app,
     path: "/graphql",
-    bodyParserConfig: { strict: false, type: "*/*" },
-    cors: {
-      origin: "http://localhost:3000",
-      credentials: true,
-    },
+    bodyParserConfig: { strict: true, type: "application/*" },
+    cors: corsPolicy,
   });
   app.listen({ port: PORT });
   console.log(`🚀 Server ready at port ${PORT}`);

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,6 +1,6 @@
 import { ApolloServer, AuthenticationError } from "apollo-server-express";
 import { connectDB } from "./database/mongoConnection";
-import * as bodyParser from "body-parser-graphql";
+import { bodyParserGraphQL } from "body-parser-graphql";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import dotenv from "dotenv";
@@ -49,7 +49,13 @@ connectDB(() => {
 function gqlServer() {
   const app = express();
   app.use(cookieParser());
-  app.use(bodyParser.graphql());
+  app.use(bodyParserGraphQL());
+  app.use(
+    cors({
+      origin: "http://localhost:3000",
+      credentials: true,
+    })
+  );
   const server = new ApolloServer({
     typeDefs,
     resolvers,
@@ -59,11 +65,8 @@ function gqlServer() {
         req.cookies !== {} ? await getUser(req.cookies.session) : null;
       if (!user) throw new AuthenticationError("Authentication Error");
       console.log("log verified", user);
-      return {
-        ...req,
-        res,
-        user,
-      };
+      console.log(req.body);
+      return { req, res, user };
     },
     dataSources: () => ({
       clients: new ClientDataSource(),
@@ -107,6 +110,7 @@ function gqlServer() {
   server.applyMiddleware({
     app,
     path: "/",
+    // bodyParserConfig: false,
     cors: {
       origin: "http://localhost:3000",
       credentials: true,


### PR DESCRIPTION
**Please pull from Secret Manager before running this branch**

**WORK DONE:**



*Server*
+ Integrated Firebase Admin SDK into server and initialized Firebase accordingly
+ Verification of session cookie on every request
  + ApolloServer context property calls `getUser` on `req.cookies.session` (if it exists)
  + getUser is a function in `auth/firebase.ts` which calls `verifyUserSessionCookie` and returns a user object with id and admin (firebase properties)
    + `verifyUserSessionCookie` calls the Firebase function `auth().verifySessionCookie` to check whether it's a valid cookie
  + AuthenticationError thrown on failure (missing or invalid cookie), otherwise `user` object is accessible to resolvers via the `context` param
    + **Note that this means that every single GraphQL query/mutation requires a session cookie - if we aren't going to do server-side rendering we will have to slightly modify this approach**
+ Applied Express middleware to ApolloServer so we can have separate HTTP requests in addition to ApolloClient communications
  + Created custom bodyParser for GraphQL queries/mutations since the default express bodyparser was being buggy for this specific use case
  + Integrated `cookieParser()` for the ApolloServer context to actually be able to do session cookie authentication 
+ Created an endpoint on the server separate from the ApolloServer called `/sessionLogin`
  + Takes the `idToken` from req.body and sends it to Firebase (`auth().createSessionCookie()`) with 5 day expiry (feel free to change)
  + Takes returned sessionCookie, adds relevant options (such as `httpOnly`) and sets cookie in client via `res.cookie`
 


*Client*
+ Small styling changes in SignInModal (meant to put in another PR but forgot to commit the firebase connection separately :/)
+ Added function in `services/auth.ts` to sign in with email and password
   + Process
     + Checks if non-empty string sent for email and password 
     + Attempts to signInWithEmailAndPassword (Firebase SDK function) 
     + Gets `idToken` from Firebase (Firebase SDK function) 
     + Posts `idToken` to server endpoint `/sessionLogin` 
     + Session cookie automatically stored by server response
  + Error messaging returned if any of the above steps fail, otherwise object with fields of empty strings
+ Hooked up above function to SignInModal such that a successful login redirects to `/admin` but any errors are displayed appropriately on failure
+ Changed how client communicates with server now that the server has express middleware applied to it
  + Used Apollo provided createHTTPLink and setContext to set link property to ApolloClient
    + `Content-Type` header set to `application/graphql` so that the server knows a graphql query is coming (signals custom body-parser I mentioned above)

Notes for Deployment @meganniu :

+ Some of the environment variables will have to change in the production environment (won't go in detail here for security issues)
+ You may have to change the `corsPolicy` in `server.ts` to make things as secure as possible while still being functional
