### PR TITLE
Add dummy admin homepage

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,6 +2,7 @@ import "./App.scss";
 import { Route, BrowserRouter as Router, Switch } from "react-router-dom";
 import React from "react";
 
+import AdminHomepage from "./pages/AdminHomepage";
 import AuthTestComponent from "./pages/AuthTestComponent";
 import ConfirmationModal from "./pages/ConfirmationModal";
 import DonorHomepage from './pages/DonorHomepage'
@@ -25,6 +26,7 @@ function App(): JSX.Element {
           <Route path='/signup' strict component={SignUpModal}></Route>
           <Route path='/verify-email' component={AuthTestComponent}></Route>
           <Route path='/password-reset-email-sent' strict component={PasswordResetEmailSentModal}></Route>
+          <Route path='/admin' component={AdminHomepage}></Route>
           <Route path='/test'>
             <RequestGroupDonorView requestGroupId="603d9b41eb57fc06447b8a23" />
           </Route>

--- a/client/src/pages/AdminHomepage.tsx
+++ b/client/src/pages/AdminHomepage.tsx
@@ -1,0 +1,12 @@
+import React, { FunctionComponent } from 'react';
+
+const AdminHomepage: FunctionComponent = () => {
+
+  return (
+    <div>
+        I am the admin homepage
+    </div>
+  );
+}
+
+export default AdminHomepage;


### PR DESCRIPTION
This PR addresses issue #72, creating the dummy admin homepage that will be populated later

Admin homepage is located at /admin

![blueprint_adminhomepage](https://user-images.githubusercontent.com/33968239/112767731-62563900-8fe6-11eb-8295-b4f40b12cd4c.png)
