### PR TITLE
Text Field Atom

### DIFF
--- a/client/src/components/atoms/TextField.tsx
+++ b/client/src/components/atoms/TextField.tsx
@@ -8,16 +8,17 @@ interface TextFieldProps {
   name: string,
   placeholder: string,
   type: "text" | "password",
+  iconClassName?: string
 }
 
 const TextField: FunctionComponent<TextFieldProps> = (props: TextFieldProps) => {
-  return <React.Fragment>
+  return <div className="text-field">
     <input
       type={props.type}
       name={props.name}
       className={
-        "text-field" +
-        (props.isErroneous ? " error" : "")
+        "text-field-input"
+        + (props.isErroneous ? " error" : "")
         + (props.type === "password" ? " password" : "")
       }
       placeholder={props.placeholder}
@@ -25,7 +26,11 @@ const TextField: FunctionComponent<TextFieldProps> = (props: TextFieldProps) => 
       onChange={props.onChange}
       disabled={props.isDisabled}
     />
-  </React.Fragment>
+    {props.iconClassName && <i className={props.iconClassName
+      + (props.isErroneous ? " error" : "")
+      + (props.isDisabled ? " disabled" : "")
+    }/>}
+  </div>
 };
 
 export { TextField };

--- a/client/src/components/atoms/TextField.tsx
+++ b/client/src/components/atoms/TextField.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from "react";
+
+interface TextFieldProps {
+  input: string,
+  isDisabled: boolean,
+  isErroneous: boolean,
+  onChange: React.ChangeEventHandler<HTMLInputElement>,
+  name: string,
+  placeholder: string,
+  type: "text" | "password",
+}
+
+const TextField: FunctionComponent<TextFieldProps> = (props: TextFieldProps) => {
+  return <React.Fragment>
+    <input
+      type={props.type}
+      name={props.name}
+      className={
+        "text-field" +
+        (props.isErroneous ? " error" : "")
+        + (props.type === "password" ? " password" : "")
+      }
+      placeholder={props.placeholder}
+      value={props.input}
+      onChange={props.onChange}
+      disabled={props.isDisabled}
+    />
+  </React.Fragment>
+};
+
+export { TextField };
+export type { TextFieldProps };

--- a/client/src/components/atoms/TextField.tsx
+++ b/client/src/components/atoms/TextField.tsx
@@ -19,7 +19,6 @@ const TextField: FunctionComponent<TextFieldProps> = (props: TextFieldProps) => 
       className={
         "text-field-input"
         + (props.isErroneous ? " error" : "")
-        + (props.type === "password" ? " password" : "")
       }
       placeholder={props.placeholder}
       value={props.input}

--- a/client/src/components/atoms/style/TextField.scss
+++ b/client/src/components/atoms/style/TextField.scss
@@ -1,23 +1,45 @@
 .text-field {
-  align-self: left;
-  border: 1px solid $input-border;
-  box-sizing: border-box;
-  border-radius: 4px;
-  padding-left: 20px;
-  line-height: 0;
+  display: inline;
 
-  &:focus {
-    outline-width: 0;
+  & > * {
+    vertical-align: middle;
   }
 
-  &:disabled {
-    background: none;
-    &::placeholder{
-      color: $disabled-text;
+  &-input {
+    align-self: left;
+    border: 1px solid $input-border;
+    box-sizing: border-box;
+    border-radius: 4px;
+    padding-left: 20px;
+    line-height: 0;
+
+    &:focus {
+      outline-width: 0;
+    }
+
+    &:disabled {
+      background: none;
+      &::placeholder {
+        color: $disabled-text;
+      }
+    }
+
+    &.error {
+      border: 1px solid $input-error;
     }
   }
 
-  &.error {
-    border: 1px solid $input-error;
+  & i {
+    margin-left: -45px;
+    font-size: 30px;
+    color: $soft-black;
+
+    &.error {
+      color: $input-error;
+    }
+
+    &.disabled {
+      color: $input-icon-color;
+    }
   }
 }

--- a/client/src/components/atoms/style/TextField.scss
+++ b/client/src/components/atoms/style/TextField.scss
@@ -10,6 +10,13 @@
     outline-width: 0;
   }
 
+  &:disabled {
+    background: none;
+    &::placeholder{
+      color: $disabled-text;
+    }
+  }
+
   &.error {
     border: 1px solid $input-error;
   }

--- a/client/src/components/atoms/style/TextField.scss
+++ b/client/src/components/atoms/style/TextField.scss
@@ -1,0 +1,16 @@
+.text-field {
+  align-self: left;
+  border: 1px solid $input-border;
+  box-sizing: border-box;
+  border-radius: 4px;
+  padding-left: 20px;
+  line-height: 0;
+
+  &:focus {
+    outline-width: 0;
+  }
+
+  &.error {
+    border: 1px solid $input-error;
+  }
+}

--- a/client/src/components/atoms/style/index.scss
+++ b/client/src/components/atoms/style/index.scss
@@ -5,3 +5,4 @@
 @import "SearchBar";
 @import "SimplePageNavigation";
 @import "Tag";
+@import "TextField";

--- a/client/src/pages/Modal.scss
+++ b/client/src/pages/Modal.scss
@@ -84,25 +84,16 @@
     color: $faded-modal-text-color;
   }
 
-  .input-field {
+  .text-field {
     width: 385px;
     height: 48.96px;
-    align-self: left;
-    border: 1px solid $input-border;
-    box-sizing: border-box;
-    border-radius: 4px;
-    padding-left: 20px;
-    line-height: 0;
   }
 
-  .input-field.password {
-    border: none;
+  .text-field.password {
     width: 325px;
-    display: flex;
-    flex-direction: row;
   }
 
-  .input-field-btn {
+  .text-field-btn {
     @include input-icon;
     width: 40px;
     font-size: 24px;
@@ -112,15 +103,8 @@
     cursor: pointer;
   }
 
-  .input-field.error {
-    border: 1px solid $input-error;
-  }
-
-  .input-field.password.error {
-    border: 1px solid $input-error;
+  .text-field.password.error {
     width: 325px;
-    display: flex;
-    flex-direction: row;
   }
 }
 

--- a/client/src/pages/Modal.scss
+++ b/client/src/pages/Modal.scss
@@ -84,16 +84,16 @@
     color: $faded-modal-text-color;
   }
 
-  .text-field {
+  .text-field-input {
     width: 385px;
     height: 48.96px;
   }
 
-  .text-field.password {
+  .text-field-input.password {
     width: 325px;
   }
 
-  .text-field-btn {
+  .text-field-input-btn {
     @include input-icon;
     width: 40px;
     font-size: 24px;
@@ -103,7 +103,7 @@
     cursor: pointer;
   }
 
-  .text-field.password.error {
+  .text-field-input.password.error {
     width: 325px;
   }
 }

--- a/client/src/pages/SignInModal.tsx
+++ b/client/src/pages/SignInModal.tsx
@@ -61,7 +61,7 @@ const SignInModal: FunctionComponent = () => {
                 placeholder="Enter your company email"
                 type="text"
                 value={email}
-                className={errors.email ? "input-field error" : "input-field"}
+                className={errors.email ? "text-field error" : "text-field"}
                 onChange={onChangeEmail}
               />
             </div>
@@ -78,15 +78,15 @@ const SignInModal: FunctionComponent = () => {
                   name="password"
                   className={
                     errors.password
-                      ? "input-field password error"
-                      : "input-field password"
+                      ? "text-field password error"
+                      : "text-field password"
                   }
                   placeholder="Enter your password"
                   value={password}
                   onChange={onChangePass}
                 />
                 <div
-                  className="input-field-btn"
+                  className="text-field-btn"
                   onClick={() => {
                     setHidePassword(!hidePassword);
                   }}

--- a/client/src/pages/SignInModal.tsx
+++ b/client/src/pages/SignInModal.tsx
@@ -61,7 +61,7 @@ const SignInModal: FunctionComponent = () => {
                 placeholder="Enter your company email"
                 type="text"
                 value={email}
-                className={errors.email ? "text-field error" : "text-field"}
+                className={errors.email ? "text-field-input error" : "text-field-input"}
                 onChange={onChangeEmail}
               />
             </div>
@@ -78,15 +78,15 @@ const SignInModal: FunctionComponent = () => {
                   name="password"
                   className={
                     errors.password
-                      ? "text-field password error"
-                      : "text-field password"
+                      ? "text-field-input password error"
+                      : "text-field-input password"
                   }
                   placeholder="Enter your password"
                   value={password}
                   onChange={onChangePass}
                 />
                 <div
-                  className="text-field-btn"
+                  className="text-field-input-btn"
                   onClick={() => {
                     setHidePassword(!hidePassword);
                   }}

--- a/client/src/pages/SignUpModal.tsx
+++ b/client/src/pages/SignUpModal.tsx
@@ -126,7 +126,7 @@ const SignUpModal: FunctionComponent = () => {
               placeholder="Enter your company email"
               type="text"
               value={email}
-              className={errors.email ? "text-field error" : "text-field"}
+              className={errors.email ? "text-field-input error" : "text-field-input"}
               onChange={onChangeEmail}
             />
           </div>
@@ -143,7 +143,7 @@ const SignUpModal: FunctionComponent = () => {
                   type="password"
                   name="password"
                   className={
-                    errors.password ? "text-field error" : "text-field"
+                    errors.password ? "text-field-input error" : "text-field-input"
                   }
                   placeholder="Enter your password"
                   value={password}

--- a/client/src/pages/SignUpModal.tsx
+++ b/client/src/pages/SignUpModal.tsx
@@ -126,7 +126,7 @@ const SignUpModal: FunctionComponent = () => {
               placeholder="Enter your company email"
               type="text"
               value={email}
-              className={errors.email ? "input-field error" : "input-field"}
+              className={errors.email ? "text-field error" : "text-field"}
               onChange={onChangeEmail}
             />
           </div>
@@ -143,7 +143,7 @@ const SignUpModal: FunctionComponent = () => {
                   type="password"
                   name="password"
                   className={
-                    errors.password ? "input-field error" : "input-field"
+                    errors.password ? "text-field error" : "text-field"
                   }
                   placeholder="Enter your password"
                   value={password}

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -172,6 +172,7 @@ $tag-background: #ededed;
 $input-icon-color: #adadad;
 $tpc-green: #004d57;
 $input-border: #e9e9e9;
+$disabled-text: #adadad;
 $input-error: #dc3545;
 
 @mixin input-icon() {

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -179,3 +179,5 @@ $input-error: #dc3545;
   color: $input-icon-color;
 }
 
+/* TextField Config */
+$soft-black: #333333;


### PR DESCRIPTION
Make text field styling from auth modals reusable.

### Normal state
![Screenshot from 2021-04-05 22-38-57](https://user-images.githubusercontent.com/20423590/113651836-bdc89c80-9660-11eb-886a-4619a27a2fc9.png)
![Screenshot from 2021-04-05 22-38-51](https://user-images.githubusercontent.com/20423590/113651842-c15c2380-9660-11eb-8c77-20872ad413df.png)

### Disabled state
![Screenshot from 2021-04-05 22-43-29](https://user-images.githubusercontent.com/20423590/113651806-b1dcda80-9660-11eb-944d-159b40e0ea6a.png)

### Error state
![Screenshot from 2021-04-05 22-47-14](https://user-images.githubusercontent.com/20423590/113651931-e3ee3c80-9660-11eb-9383-919318a4851f.png)
![Screenshot from 2021-04-05 22-38-33](https://user-images.githubusercontent.com/20423590/113651858-c7ea9b00-9660-11eb-8659-0ba727c2a234.png)

### Password textfield
![Screenshot from 2021-04-05 22-47-44](https://user-images.githubusercontent.com/20423590/113651967-f4061c00-9660-11eb-810e-4d88618cd0e9.png)
