### PR TITLE
Search client by name

### DIFF
--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -41,6 +41,16 @@ const nextRequestRequestGroupHelper = (requestTypeIds, dataSources): RequestInte
 const resolvers = {
   Query: {
     client: (_, { id }, { dataSources }): ClientInterface => dataSources.clients.getById(Types.ObjectId(id)),
+    filterClient: (_, { id, clientId, fullName, deleted }, { dataSources }): Array<ClientInterface> => {
+      const clients = dataSources.clients.getAll()
+
+      console.log(fullName)
+
+      return clients.filter((client) => (id ? client._id.equals(Types.ObjectId(id)) : true) 
+                                        && (clientId ? client.clientId === clientId : true)
+                                        && (fullName ? client.fullName === fullName : true)
+                                        && (deleted ? client.deleted === deleted : true))
+    },
     clients: (_, __, { dataSources }): Array<ClientInterface> => dataSources.clients.getAll(),
     request: (_, { id }, { dataSources }): RequestInterface => dataSources.requests.getById(Types.ObjectId(id)),
     requests: (_, __, { dataSources }): Array<RequestInterface> => dataSources.requests.getAll(),

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -44,8 +44,6 @@ const resolvers = {
     filterClient: (_, { id, clientId, fullName, deleted }, { dataSources }): Array<ClientInterface> => {
       const clients = dataSources.clients.getAll()
 
-      console.log(fullName)
-
       return clients.filter((client) => (id ? client._id.equals(Types.ObjectId(id)) : true) 
                                         && (clientId ? client.clientId === clientId : true)
                                         && (fullName ? client.fullName === fullName : true)

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -48,11 +48,6 @@ const resolvers = {
         filteredClients = filteredClients.filter((client) => (client[property] ? client[property] === filter[property] : true))
       }
 
-      /*return clients.filter((client) => (filter.id ? client._id.equals(Types.ObjectId(filter.id)) : true) 
-                                        && (filter.clientId ? client.clientId === filter.clientId : true)
-                                        && (filter.fullName ? client.fullName === filter.fullName : true)
-                                        && (filter.deleted ? client.deleted === filter.deleted : true))
-                                        */
       return filteredClients
     },
     clients: (_, __, { dataSources }): Array<ClientInterface> => dataSources.clients.getAll(),

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -41,13 +41,13 @@ const nextRequestRequestGroupHelper = (requestTypeIds, dataSources): RequestInte
 const resolvers = {
   Query: {
     client: (_, { id }, { dataSources }): ClientInterface => dataSources.clients.getById(Types.ObjectId(id)),
-    filterClient: (_, { id, clientId, fullName, deleted }, { dataSources }): Array<ClientInterface> => {
+    filterClients: (_, { filter }, { dataSources }): Array<ClientInterface> => {
       const clients = dataSources.clients.getAll()
 
-      return clients.filter((client) => (id ? client._id.equals(Types.ObjectId(id)) : true) 
-                                        && (clientId ? client.clientId === clientId : true)
-                                        && (fullName ? client.fullName === fullName : true)
-                                        && (deleted ? client.deleted === deleted : true))
+      return clients.filter((client) => (filter.id ? client._id.equals(Types.ObjectId(filter.id)) : true) 
+                                        && (filter.clientId ? client.clientId === filter.clientId : true)
+                                        && (filter.fullName ? client.fullName === filter.fullName : true)
+                                        && (filter.deleted ? client.deleted === filter.deleted : true))
     },
     clients: (_, __, { dataSources }): Array<ClientInterface> => dataSources.clients.getAll(),
     request: (_, { id }, { dataSources }): RequestInterface => dataSources.requests.getById(Types.ObjectId(id)),

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -42,12 +42,18 @@ const resolvers = {
   Query: {
     client: (_, { id }, { dataSources }): ClientInterface => dataSources.clients.getById(Types.ObjectId(id)),
     filterClients: (_, { filter }, { dataSources }): Array<ClientInterface> => {
-      const clients = dataSources.clients.getAll()
+      var filteredClients = dataSources.clients.getAll()
 
-      return clients.filter((client) => (filter.id ? client._id.equals(Types.ObjectId(filter.id)) : true) 
+      for (var property in filter) {
+        filteredClients = filteredClients.filter((client) => (client[property] ? client[property] === filter[property] : true))
+      }
+
+      /*return clients.filter((client) => (filter.id ? client._id.equals(Types.ObjectId(filter.id)) : true) 
                                         && (filter.clientId ? client.clientId === filter.clientId : true)
                                         && (filter.fullName ? client.fullName === filter.fullName : true)
                                         && (filter.deleted ? client.deleted === filter.deleted : true))
+                                        */
+      return filteredClients
     },
     clients: (_, __, { dataSources }): Array<ClientInterface> => dataSources.clients.getAll(),
     request: (_, { id }, { dataSources }): RequestInterface => dataSources.requests.getById(Types.ObjectId(id)),

--- a/server/graphql/resolvers.ts
+++ b/server/graphql/resolvers.ts
@@ -42,9 +42,9 @@ const resolvers = {
   Query: {
     client: (_, { id }, { dataSources }): ClientInterface => dataSources.clients.getById(Types.ObjectId(id)),
     filterClients: (_, { filter }, { dataSources }): Array<ClientInterface> => {
-      var filteredClients = dataSources.clients.getAll()
+      let filteredClients = dataSources.clients.getAll()
 
-      for (var property in filter) {
+      for (let property in filter) {
         filteredClients = filteredClients.filter((client) => (client[property] ? client[property] === filter[property] : true))
       }
 

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -54,7 +54,8 @@ const typeDefs = gql`
     }
     type Query {
         client(id: ID): Client
-        clients(id: ID): [Client]
+        filterClient(id: ID, clientId: String, fullName: String, deleted: Boolean): [Client]
+        clients: [Client]
         request(id: ID): Request
         requests: [Request]
         requestType(id: ID): RequestType

--- a/server/graphql/schema.ts
+++ b/server/graphql/schema.ts
@@ -54,7 +54,7 @@ const typeDefs = gql`
     }
     type Query {
         client(id: ID): Client
-        filterClient(id: ID, clientId: String, fullName: String, deleted: Boolean): [Client]
+        filterClients(filter: ClientInput): [Client]
         clients: [Client]
         request(id: ID): Request
         requests: [Request]
@@ -106,6 +106,7 @@ const typeDefs = gql`
         id: ID
         clientId: String
         fullName: String
+        deleted: Boolean
     }
 `
 


### PR DESCRIPTION
See https://www.notion.so/uwblueprintexecs/Server-Find-client-when-creating-updating-request-d460bc2d300046a79a53fc74ba9e2ee5

We needed a way for the user of the API to query clients by their fullName. To generalize this:

- new endpoint called filterClients that takes as input a "filter" object that has all the parameters of a client
- this endpoint returns an array of Clients, filtered by whichever properties of the filter object are defined

This generalization implements filtering on any property of a Client.

I left commented out a second working approach. Not sure which approach is best.

E.g:
![image](https://user-images.githubusercontent.com/32274856/113923672-cfbc5380-97b6-11eb-81f7-87a3c1d053cc.png)
