### PR TITLE
RichTextField and RichTextDisplay

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1303,27 +1303,6 @@
         "@firebase/app-types": "0.6.1"
       }
     },
-    "@firebase/firestore": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.7.tgz",
-      "integrity": "sha512-sh+aX6udS8a+rwmlJO4zJwvoMC1D2x1CiPvj0nFYWhILRKWvztk/bOA3lT2FWcHY4kr/7x+CnqfwtiOSaufdNQ==",
-      "requires": {
-        "@firebase/component": "0.2.0",
-        "@firebase/firestore-types": "2.1.0",
-        "@firebase/logger": "0.2.6",
-        "@firebase/util": "0.3.4",
-        "@firebase/webchannel-wrapper": "0.4.1",
-        "@grpc/grpc-js": "^1.0.0",
-        "@grpc/proto-loader": "^0.5.0",
-        "node-fetch": "2.6.1",
-        "tslib": "^1.11.1"
-      }
-    },
-    "@firebase/firestore-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.1.0.tgz",
-      "integrity": "sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ=="
-    },
     "@firebase/functions": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.2.tgz",
@@ -1474,9 +1453,9 @@
       "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
     },
     "@grpc/grpc-js": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.8.tgz",
-      "integrity": "sha512-9C1xiCbnYe/3OFpSuRqz2JgFSOxv6+SlqFhXgRC1nHfXYbLnXvtmsI/NpaMs6k9ZNyV4gyaOOh5Z4McfegQGew==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
+      "integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
       "requires": {
         "@types/node": ">=12.12.47",
         "google-auth-library": "^6.1.1",
@@ -4230,15 +4209,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -7259,12 +7229,6 @@
         }
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "optional": true
-    },
     "filesize": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
@@ -7345,6 +7309,29 @@
         "@firebase/remote-config": "0.1.31",
         "@firebase/storage": "0.4.3",
         "@firebase/util": "0.3.4"
+      },
+      "dependencies": {
+        "@firebase/firestore": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.7.tgz",
+          "integrity": "sha512-sh+aX6udS8a+rwmlJO4zJwvoMC1D2x1CiPvj0nFYWhILRKWvztk/bOA3lT2FWcHY4kr/7x+CnqfwtiOSaufdNQ==",
+          "requires": {
+            "@firebase/component": "0.2.0",
+            "@firebase/firestore-types": "2.1.0",
+            "@firebase/logger": "0.2.6",
+            "@firebase/util": "0.3.4",
+            "@firebase/webchannel-wrapper": "0.4.1",
+            "@grpc/grpc-js": "^1.0.0",
+            "@grpc/proto-loader": "^0.5.0",
+            "node-fetch": "2.6.1",
+            "tslib": "^1.11.1"
+          }
+        },
+        "@firebase/firestore-types": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.1.0.tgz",
+          "integrity": "sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ=="
+        }
       }
     },
     "flat-cache": {
@@ -7651,9 +7638,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "optional": true
     },
     "fstream": {
@@ -7736,9 +7723,9 @@
       }
     },
     "gaxios": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-      "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -13581,9 +13568,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
-          "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow=="
+          "version": "13.13.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.48.tgz",
+          "integrity": "sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ=="
         }
       }
     },
@@ -17152,7 +17139,6 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -17755,7 +17741,6 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2588,6 +2588,16 @@
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
       "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw=="
     },
+    "@types/draft-js": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@types/draft-js/-/draft-js-0.11.1.tgz",
+      "integrity": "sha512-jV4LAXYdVvS0ahIROZehkKqHgfLxaDBl3fzfEVqho8NxFAtEaObdIiu7FpPUu/Y97PlJVxGajar7aSikQqz9sQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "immutable": "~3.7.4"
+      }
+    },
     "@types/eslint": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
@@ -5137,6 +5147,14 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5932,6 +5950,16 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "draft-js": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/draft-js/-/draft-js-0.11.7.tgz",
+      "integrity": "sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==",
+      "requires": {
+        "fbjs": "^2.0.0",
+        "immutable": "~3.7.4",
+        "object-assign": "^4.1.1"
+      }
     },
     "duplexer": {
       "version": "0.1.2",
@@ -7166,6 +7194,36 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fbjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-2.0.0.tgz",
+      "integrity": "sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==",
+      "requires": {
+        "core-js": "^3.6.4",
+        "cross-fetch": "^3.0.4",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        }
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -8452,6 +8510,11 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
       "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -16597,6 +16660,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "uncontrollable": {
       "version": "7.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "apollo-link-http": "^1.5.17",
     "bootstrap": "^4.6.0",
     "bootstrap-icons": "^1.4.0",
+    "draft-js": "^0.11.7",
     "firebase": "^8.2.9",
     "graphql": "^15.5.0",
     "moment": "^2.29.1",
@@ -57,6 +58,7 @@
     ]
   },
   "devDependencies": {
+    "@types/draft-js": "^0.11.1",
     "@types/react-copy-to-clipboard": "^5.0.0",
     "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.14.2",

--- a/client/src/App.scss
+++ b/client/src/App.scss
@@ -1,3 +1,5 @@
 @import "~bootstrap/scss/bootstrap";
-@import "style/style.scss";
 @import 'bootstrap-icons/font/bootstrap-icons.css';
+@import 'draft-js/dist/Draft.css';
+
+@import "style/style.scss";

--- a/client/src/components/atoms/RichTextDisplay.tsx
+++ b/client/src/components/atoms/RichTextDisplay.tsx
@@ -1,0 +1,24 @@
+import { convertFromRaw, Editor, EditorState } from 'draft-js';
+import React, { FunctionComponent, useEffect } from 'react';
+
+interface Props {
+    content: string
+}
+
+const RichTextDisplay: FunctionComponent<Props> = (props: Props) => {
+    const [editorState, setEditorState] = React.useState(EditorState.createEmpty())
+
+    useEffect(() => {
+        if (props.content) {
+            setEditorState(EditorState.createWithContent(convertFromRaw(JSON.parse(props.content))))
+        }
+    }, [props.content])
+
+    return (
+        <div className="richtext-display">
+            <Editor editorState={editorState} readOnly={true} onChange={() => {}}/>
+        </div>
+    )
+};
+
+export default RichTextDisplay;

--- a/client/src/components/atoms/RichTextField.tsx
+++ b/client/src/components/atoms/RichTextField.tsx
@@ -1,0 +1,149 @@
+import { ContentState, convertFromRaw, convertToRaw, Editor, EditorState, getDefaultKeyBinding, KeyBindingUtil, Modifier, RichUtils, SelectionState } from 'draft-js';
+import React, { FunctionComponent, useState } from 'react';
+
+import ScrollWindow from './ScrollWindow';
+
+interface Props {
+    initialContent: string
+    defaultText: string
+    onChange: (content : string) => void
+    isErroneous: boolean
+}
+
+const RichTextField: FunctionComponent<Props> = (props: Props) => {
+    const [active, setActive] = React.useState(false) // whether we have entered any content beyond the default text
+    const [editorState, setEditorState] = React.useState(
+        props.initialContent ?
+        EditorState.createWithContent(convertFromRaw(JSON.parse(props.initialContent))) :
+        EditorState.createWithContent(ContentState.createFromText(props.defaultText)))
+
+    const { hasCommandModifier } = KeyBindingUtil;
+    function keyBindings(e : React.KeyboardEvent): string | null {
+        const selection = editorState.getSelection()
+        const block = editorState.getCurrentContent().getBlockForKey(selection.getAnchorKey())
+    
+        if (e.key === "b" && hasCommandModifier(e)) {
+            return 'bold'
+        }
+    
+        if (e.key === " " && selection.getAnchorOffset() === 1 && block.getText().trim().charAt(0) === "-" && block.getType() !== 'unordered-list-item') {
+            return 'make-list'
+        }
+    
+        if (e.key === "Backspace" && block.getType() !== 'unstyled' && block.getText().length === 0) {
+            return 'remove-block-styling'
+        }
+        
+        return getDefaultKeyBinding(e)
+    }
+
+    function clearState(currentState: EditorState) {
+        const blocks = currentState.getCurrentContent().getBlockMap().toList()
+        const allSelection = editorState.getSelection().merge({
+            anchorKey: blocks.first().get('key'),
+            anchorOffset: 0,
+            focusKey: blocks.last().get('key'),
+            focusOffset: blocks.last().getLength(),
+        })
+        const newContent = Modifier.removeRange(editorState.getCurrentContent(), allSelection, 'backward')
+
+        const clearedState = EditorState.push(currentState, newContent, 'remove-range')
+        setEditorState(EditorState.forceSelection(clearedState, newContent.getSelectionAfter()))
+    }
+
+    function onChange(state: EditorState) {
+        // check if we started with defaultText, if so clear state
+        if (!active && !props.initialContent) { 
+            clearState(state)
+            setActive(true)
+            return
+        }
+
+        // check if we are already typing (we are active) and state has no text
+        if (active && !state.getCurrentContent().hasText()) {
+            props.onChange(JSON.stringify(convertToRaw(state.getCurrentContent())));
+            setEditorState(EditorState.createWithContent(ContentState.createFromText(props.defaultText)))
+            setActive(false)
+            return
+        }
+
+        props.onChange(JSON.stringify(convertToRaw(state.getCurrentContent())));
+        setEditorState(state);
+    }
+
+    function handleKeyCommand(command : string, state : EditorState ) {
+        const selection = state.getSelection()
+        const block = editorState.getCurrentContent().getBlockForKey(selection.getAnchorKey())
+
+        if (command === 'bold') {
+            onChange(RichUtils.toggleInlineStyle(state, 'BOLD'))
+            return 'handled'
+        } 
+        
+        if (command === 'make-list') {
+            let modifiedContent = state.getCurrentContent()
+
+            if (block.getText().trim().charAt(0) === "-") {
+                const replacementRange = new SelectionState({
+                    anchorKey: selection.getAnchorKey(),
+                    anchorOffset: 0,
+                    focusKey: selection.getFocusKey(),
+                    focusOffset: 1
+                })
+
+                modifiedContent = Modifier.replaceText(state.getCurrentContent(), replacementRange, "")
+            }
+            
+            const modifiedState = RichUtils.toggleBlockType(EditorState.push(state, modifiedContent, 'delete-character'), 'unordered-list-item')
+
+            const newSelection = new SelectionState({
+                anchorKey: modifiedState.getSelection().getAnchorKey(),
+                anchorOffset: 0,
+                focusKey: modifiedState.getSelection().getAnchorKey(),
+                focusOffset: 0
+            })
+
+            onChange(EditorState.forceSelection(modifiedState, newSelection))
+            return 'handled'
+        }
+
+        if (command === 'remove-block-styling') {
+            onChange(RichUtils.toggleBlockType(state, 'unstyled'))
+            return 'handled'
+        }
+  
+        return 'not-handled'
+    }
+
+    function handleControlMouseDown(e : React.MouseEvent<HTMLElement>, modifiedState : EditorState) {
+        e.preventDefault()
+        
+        const nextEditorState = EditorState.acceptSelection(
+            modifiedState,
+            modifiedState.getSelection().merge({
+                hasFocus: true
+            })
+        );
+        onChange(modifiedState)
+    }
+
+    return (
+        <div className={"richtext-field" + (!active ? " default" : "") + (props.isErroneous ? " error" : "")}>
+            <div className="richtext-field-controls">
+                <button onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleInlineStyle(editorState, 'BOLD'))}>
+                    <i className="bi bi-type-bold"/>
+                </button>
+                <button onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleBlockType(editorState, 'unordered-list-item'))}>
+                    <i className="bi bi-list-ul"/>
+                </button>
+            </div>
+            <div className="richtext-field-input">
+                <ScrollWindow>
+                    <Editor editorState={editorState} onChange={onChange} handleKeyCommand={handleKeyCommand} keyBindingFn={keyBindings}/>
+                </ScrollWindow>
+            </div>
+        </div>
+    )
+};
+
+export default RichTextField;

--- a/client/src/components/atoms/style/RichTextDisplay.scss
+++ b/client/src/components/atoms/style/RichTextDisplay.scss
@@ -1,0 +1,8 @@
+.richtext-display {
+    .public-DraftEditor-content {
+        @include normal-text;
+        font-size: 14px;
+        line-height: 21px;
+        color: $grey-text-color;
+    }
+}

--- a/client/src/components/atoms/style/RichTextField.scss
+++ b/client/src/components/atoms/style/RichTextField.scss
@@ -1,0 +1,59 @@
+.richtext-field {
+    width: 484px;
+    height: 252px;
+    margin-left: 500px;
+    overflow: hidden;
+
+    background-color: $background;
+    border: 1px solid $dark-border-color;
+    box-sizing: border-box;
+    border-radius: 4px 4px 0 0;
+
+    &.error {
+        border-color: $error-color;
+    }
+}
+
+.richtext-field-controls {
+    width: 100%;
+    border-bottom: 1px solid $window-border-color;
+
+    .error & {
+        border-color: $error-color;
+    }
+
+    button {
+        width: 32px;
+        height: 32px;
+        background-color: transparent;
+        border: none;
+        border-right: 1px solid $window-border-color;
+
+        i {
+            width: 12px;
+            height: 12px;
+        }
+    }
+}
+
+.richtext-field-input {
+    height: 220px;
+    max-height: 220px;
+    overflow-y: hidden;
+
+    .public-DraftEditor-content {
+        @include normal-text;
+        font-size: 14px;
+        line-height: 21px;
+        color: $grey-text-color;
+        padding: 12px 22px 0 22px;
+
+        .default & {
+            color: $dark-border-color;
+        }
+
+        .error & {
+            @include error-text;
+        }
+    }
+}

--- a/client/src/components/atoms/style/RichTextField.scss
+++ b/client/src/components/atoms/style/RichTextField.scss
@@ -40,6 +40,16 @@
     height: 220px;
     max-height: 220px;
     overflow-y: hidden;
+    
+    .richtext-default-text {
+        @include normal-text;
+        position: absolute;
+        font-size: 14px;
+        line-height: 21px;
+        color: $grey-text-color;
+        padding: 12px 22px 0 22px;
+        color: $dark-border-color;
+    }
 
     .scroll-window {
         border: none;
@@ -51,10 +61,6 @@
         line-height: 21px;
         color: $grey-text-color;
         padding: 12px 22px 0 22px;
-
-        .default & {
-            color: $dark-border-color;
-        }
 
         .error & {
             @include error-text;

--- a/client/src/components/atoms/style/RichTextField.scss
+++ b/client/src/components/atoms/style/RichTextField.scss
@@ -41,6 +41,10 @@
     max-height: 220px;
     overflow-y: hidden;
 
+    .scroll-window {
+        border: none;
+    }
+
     .public-DraftEditor-content {
         @include normal-text;
         font-size: 14px;
@@ -55,5 +59,9 @@
         .error & {
             @include error-text;
         }
+    }
+
+    .DraftEditor-editorContainer {
+        border: none;
     }
 }

--- a/client/src/components/atoms/style/index.scss
+++ b/client/src/components/atoms/style/index.scss
@@ -3,6 +3,8 @@
 @import "PageNavigation";
 @import "RequestGroupListItem";
 @import "RequestTypeListItem";
+@import "RichTextDisplay";
+@import "RichTextField";
 @import "SearchBar";
 @import "SimplePageNavigation";
 @import "Tag";

--- a/client/src/components/molecules/InfoBox.tsx
+++ b/client/src/components/molecules/InfoBox.tsx
@@ -7,7 +7,8 @@ import type {ButtonProps} from '../atoms/Button';
 
 interface Props {
     title: string,
-    text: string,
+    text?: string,
+    children?: React.ReactNode,
     buttonProps?: ButtonProps
 }
 
@@ -18,9 +19,12 @@ const InfoBox: FunctionComponent<Props> = (props: Props) => {
                 <Card.Title>
                     {props.title}
                 </Card.Title>
-                <Card.Text>
-                    {props.text}
-                </Card.Text>
+                {props.text &&
+                    <Card.Text>
+                        {props.text}
+                    </Card.Text>
+                }
+                {props.children}
                 {props.buttonProps &&
                     <Button {...props.buttonProps}/>
                 }

--- a/client/src/components/organisms/RequestGroupDonorView.tsx
+++ b/client/src/components/organisms/RequestGroupDonorView.tsx
@@ -7,6 +7,7 @@ import { Row, Spinner } from 'react-bootstrap';
 import InfoBox from '../molecules/InfoBox';
 import RequestGroup from '../../data/types/requestGroup';
 import RequestTypeList from '../molecules/RequestTypeList';
+import RichTextDisplay from "../atoms/RichTextDisplay";
 
 // TODO: rich text for descriptions (BLOCKER: how admin's will set descriptions)
 // TODO: get email from TPC and put here
@@ -96,10 +97,9 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
                         }}
                     />
                     <div id="description">
-                        <InfoBox 
-                            title="ITEM DESCRIPTION" 
-                            text={requestGroupData.description ? requestGroupData.description : ''}
-                        />
+                        <InfoBox title="ITEM DESCRIPTION">
+                            {requestGroupData.description && <RichTextDisplay content={requestGroupData.description}/>}
+                        </InfoBox>
                     </div>
                 </div>
             </div>}

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -202,7 +202,3 @@ $soft-black: #333333;
 /* ScrollWindow Config */
 $scroll-bar-color: #C4C4C4;
 $scroll-window-border: 1px solid $window-border-color;
-
-/* DraftJS Config */
-.public-DraftEditor-content {
-}

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -16,8 +16,10 @@ $selected-item-background: #f7f7f7;
 $font-stack: "Inter", sans-serif;
 $faded-text-color: #afafaf;
 $alt-faded-text-color: #a3a3a3;
+$grey-text-color: #333333;
 $faded-modal-text-color: #7d7d7d;
 $normal-text-color: black;
+$error-text-color: #e7b0b5;
 $white-text-color: white;
 $section-header-text-color: #bbbbbb;
 $tooltip-background-color: #efefef;
@@ -25,6 +27,9 @@ $tooltip-text-color: #737b7d;
 $tooltip-trigger-color: #adadad;
 $alert-light-color: #f8d7da;
 $alert-dark-color: #721c24;
+$error-color: #dc3545;
+$dark-border-color: #797979;
+$window-border-color: #d7d7d7;
 
 @mixin text() {
   font-family: $font-stack;
@@ -35,6 +40,11 @@ $alert-dark-color: #721c24;
 @mixin normal-text() {
   @include text;
   color: $normal-text-color;
+}
+
+@mixin error-text() {
+  @include text;
+  color: $error-text-color;
 }
 
 @mixin white-text() {
@@ -151,7 +161,7 @@ $tag-background: #ededed;
   margin-top: 20px;
 
   .a {
-    color: #333333;
+    color: $grey-text-color;
   }
 
   & td {
@@ -178,7 +188,7 @@ $input-icon-color: #adadad;
 $tpc-green: #004d57;
 $input-border: #e9e9e9;
 $disabled-text: #adadad;
-$input-error: #dc3545;
+$input-error: $error-color;
 $tpc-green-hover: #00363e;
 
 @mixin input-icon() {
@@ -191,4 +201,8 @@ $soft-black: #333333;
 
 /* ScrollWindow Config */
 $scroll-bar-color: #C4C4C4;
-$scroll-window-border: 1px solid #D7D7D7;
+$scroll-window-border: 1px solid $window-border-color;
+
+/* DraftJS Config */
+.public-DraftEditor-content {
+}

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -2,7 +2,6 @@ import dotenv from 'dotenv'
 import { exit } from 'process'
 import faker from 'faker'
 import mongoose from 'mongoose'
-import { convertToRaw, ContentState, EditorState } from 'draft-js'
 
 import { connectDB } from '../database/mongoConnection'
 

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv'
 import { exit } from 'process'
 import faker from 'faker'
 import mongoose from 'mongoose'
+import { convertToRaw, ContentState, EditorState } from 'draft-js'
 
 import { connectDB } from '../database/mongoConnection'
 
@@ -9,7 +10,6 @@ import { Client } from '../models/clientModel'
 import { Request } from '../models/requestModel'
 import { RequestGroup } from '../models/requestGroupModel'
 import { RequestType } from '../models/requestTypeModel'
-import { start } from 'repl'
 
 // -----------------------------------------------------------------------------
 // SEED REQUESTS/TAGS
@@ -94,7 +94,8 @@ const createRequestGroup = (groupID, typeIDs, errMsg) => {
   const group = new RequestGroup({
     _id: groupID,
     name: faker.random.arrayElement(requestGroupNames),
-    description: faker.lorem.sentence(),
+    // description is in the format specified by DraftJS
+    description: '{"blocks":[{"key":"bv0s8","text":"' + faker.lorem.sentence() + '","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[],"data":{}}],"entityMap":{}}',
     requirements: faker.lorem.sentence(),
     image: faker.random.arrayElement(requestGroupImages),
   })


### PR DESCRIPTION
This ended up being super complicated and filled with logic. Apologies in advance for reviewers. (there is a very good reason Github uses markdown). 

To fully understand the code, unfortunately a foundation in Draft.js is useful- contact me if needed! I've added comments for most things a quick dive into Draft.js wouldn't bring up.

**ADDED:**
- Draft.js module to client. Chosen instead of Quill.js for customizability and ease of using with "sanitation".
- RichTextField component (read and write). Supports bold input with a button and key commands. Supports unordered list input with a button and key commands
- RichTextDisplay component (read only, for rendering rich text created by using RichTextField)

**MODIFIED:**
- Seeder now uses the Draft.js format (thus database has requestGroup.description in the correct format)
- RequestGroupDonorView now shows descriptions for requestGroups using RichTextDisplay
- InfoBox modified to have children (so we can easily use RichTextDisplay)
- Moved a bunch of colors around in _config.scss to better reflect how we are using them

![image](https://user-images.githubusercontent.com/32274856/114293644-ea682400-9a65-11eb-9ebe-09109d825d19.png)
![image](https://user-images.githubusercontent.com/32274856/114293648-f522b900-9a65-11eb-8abc-527eb259cc3d.png)
![image](https://user-images.githubusercontent.com/32274856/114293660-023fa800-9a66-11eb-89ef-429b3dca0b78.png)
![image](https://user-images.githubusercontent.com/32274856/114293667-0c61a680-9a66-11eb-8644-873e8a4e2584.png)
![image](https://user-images.githubusercontent.com/32274856/114293694-27341b00-9a66-11eb-87e0-1b48d75c5074.png)


