### PR TITLE
Create/Edit Request Group Modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,8 @@ import SendResetPasswordEmailModal from "./pages/SendResetPasswordEmailModal";
 import SignInModal from "./pages/SignInModal";
 import SignUpModal from "./pages/SignUpModal";
 
+import RequestGroupFormContainer from './components/examples/RequestGroupFormContainer'
+
 
 function App(): JSX.Element {
   return (
@@ -29,6 +31,7 @@ function App(): JSX.Element {
           <Route path='/test'>
             <RequestGroupDonorView requestGroupId="603d9b41eb57fc06447b8a23" />
           </Route>
+          <Route path='/request-group-form' component={RequestGroupFormContainer}></Route>
           <Route path='/'><DonorHomepage /></Route>
         </Switch>
       </Router>

--- a/client/src/components/atoms/AlertDialog.tsx
+++ b/client/src/components/atoms/AlertDialog.tsx
@@ -11,8 +11,8 @@ const AlertDialog: FunctionComponent<Props> = (props: Props) => {
         <div className="alert-dialog">
             <p className="alert-display-text">{props.dialogText}</p>
             <p className="alert-prompt">Are you sure you want to leave?</p>
-            <button className="alert-stay-button" onClick={props.onExit}>Keep Editing</button>
-            <button className="alert-leave-button" onClick={props.onStay}>Leave</button>
+            <button className="alert-stay-button" onClick={props.onStay}>Keep Editing</button>
+            <button className="alert-leave-button" onClick={props.onExit}>Leave</button>
         </div>
     )
 }

--- a/client/src/components/atoms/Button.tsx
+++ b/client/src/components/atoms/Button.tsx
@@ -4,7 +4,7 @@ import {CopyToClipboard} from 'react-copy-to-clipboard';
 
 interface ButtonProps {
     text: string,
-    onClick: React.MouseEventHandler<HTMLButtonElement>,
+    onClick?: React.MouseEventHandler<HTMLButtonElement>,
     copyText: string
 }
 

--- a/client/src/components/atoms/DeletableTag.tsx
+++ b/client/src/components/atoms/DeletableTag.tsx
@@ -1,16 +1,15 @@
 import React, { FunctionComponent } from "react";
 
 interface Props {
-    id: number,
     text: string,
-    onDelete: (id: number) => void
+    onDelete: (text: string) => void
 }
 
 const DeletableTag: FunctionComponent<Props> = (props: Props) => {
     return (
         <div className="deletable-tag">
             <span className="tag">
-                <i className="bi bi-x" style={{marginRight:"5px"}} onClick={()=> props.onDelete(props.id)}></i>
+                <i className="bi bi-x" style={{marginRight:"5px"}} onClick={()=> props.onDelete(props.text)}></i>
                 {props.text}
             </span>
         </div>

--- a/client/src/components/atoms/ImagePicker.tsx
+++ b/client/src/components/atoms/ImagePicker.tsx
@@ -13,7 +13,6 @@ const ImagePicker: FunctionComponent<Props> = (props: Props) => {
   const { selected, images, onImageChange, isErroneous } = props;
   return (
     <div className="imagepicker">
-      {isErroneous && <i className="bi bi-exclamation-circle alert-icon"></i>}
       <div className={`imagepicker-preview`}>
         {selected.length ? (
           <img src={selected} />

--- a/client/src/components/atoms/ImagePicker.tsx
+++ b/client/src/components/atoms/ImagePicker.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent } from "react";
 import ImageList from "./ImageList";
-import Row from "react-bootstrap/Row";
 
 interface Props {
   onImageChange(url: string): void;

--- a/client/src/components/atoms/RichTextField.tsx
+++ b/client/src/components/atoms/RichTextField.tsx
@@ -1,5 +1,5 @@
-import { ContentState, convertFromRaw, convertToRaw, Editor, EditorState, getDefaultKeyBinding, KeyBindingUtil, Modifier, RichUtils, SelectionState } from 'draft-js';
-import React, { FunctionComponent, useState } from 'react';
+import { convertFromRaw, convertToRaw, Editor, EditorState, getDefaultKeyBinding, KeyBindingUtil, Modifier, RichUtils, SelectionState } from 'draft-js';
+import React, { FunctionComponent } from 'react';
 
 import ScrollWindow from './ScrollWindow';
 

--- a/client/src/components/atoms/RichTextField.tsx
+++ b/client/src/components/atoms/RichTextField.tsx
@@ -125,10 +125,14 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
     return (
         <div className={"richtext-field" + (props.isErroneous ? " error" : "")}>
             <div className="richtext-field-controls">
-                <button onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleInlineStyle(editorState, 'BOLD'))}>
+                <button 
+                    onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleInlineStyle(editorState, 'BOLD'))} 
+                    onClick={(e) => {e.preventDefault()}}>
                     <i className="bi bi-type-bold"/>
                 </button>
-                <button onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleBlockType(editorState, 'unordered-list-item'))}>
+                <button 
+                    onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleBlockType(editorState, 'unordered-list-item'))} 
+                    onClick={(e) => {e.preventDefault()}}>
                     <i className="bi bi-list-ul"/>
                 </button>
             </div>

--- a/client/src/components/atoms/RichTextField.tsx
+++ b/client/src/components/atoms/RichTextField.tsx
@@ -5,11 +5,12 @@ import ScrollWindow from './ScrollWindow';
 
 interface Props {
     initialContent: string // content in the stringified form of a ContentState (i.e. derived from using RichTextField)
-                           // this should not be reactive! (not updated onChange)
-                           // how to use: for editing pre-existing content (e.g. on editing a requestGroup's description),
-                           //             pass the previous description into initialContent
+    // this should not be reactive! (not updated onChange)
+    // how to use: for editing pre-existing content (e.g. on editing a requestGroup's description),
+    //             pass the previous description into initialContent
     defaultText: string // text to show if no content in input field
-    onChange: (content : string) => void // called with stringified form of current ContentState
+    onChange: (content: string) => void // called with stringified form of current ContentState
+    onEmpty?: () => void
     isErroneous: boolean // for styling when the input is erroneous
 }
 
@@ -17,32 +18,32 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
     const [active, setActive] = React.useState(false) // whether we have entered any content beyond the default text
     const [editorState, setEditorState] = React.useState(
         props.initialContent ?
-        EditorState.createWithContent(convertFromRaw(JSON.parse(props.initialContent))) :
-        EditorState.createEmpty())
+            EditorState.createWithContent(convertFromRaw(JSON.parse(props.initialContent))) :
+            EditorState.createEmpty())
 
     const { hasCommandModifier } = KeyBindingUtil; // utility
     // for each key input, map keys to commands conditionally
-    function keyBindings(e : React.KeyboardEvent): string | null {
+    function keyBindings(e: React.KeyboardEvent): string | null {
         const selection = editorState.getSelection()
         const block = editorState.getCurrentContent().getBlockForKey(selection.getAnchorKey())
-    
+
         // CTRL+B (or CMD+B on Mac)
         if (e.key === "b" && hasCommandModifier(e)) {
             return 'bold'
         }
-    
+
         // If we are entering a space " " that is the second character in the block and the first character is "-"
         // then make this block an unordered list if it is not already one
         if (e.key === " " && selection.getAnchorOffset() === 1 && block.getText().trim().charAt(0) === "-" && block.getType() !== 'unordered-list-item') {
             return 'make-list'
         }
-    
+
         // If we are hitting backspace on an empty block with styling, we want the block to be reset to default styling
         // E.g.: backspace on an empty unordered list removes the list, backspace once more then can remove the block
         if (e.key === "Backspace" && block.getType() !== 'unstyled' && block.getText().length === 0) {
             return 'remove-block-styling'
         }
-        
+
         return getDefaultKeyBinding(e) // standard input (e.g. typing "e" inputs "e" at cursor, backspace deletes char before cursor)
     }
 
@@ -52,19 +53,27 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
             setActive(true)
         }
 
+        let emptyContent = false;
         // check if we are already typing (we are active) and state has no text
         if (active && (!state.getCurrentContent().hasText() && state.getCurrentContent().getFirstBlock().getType() === 'unstyled')) {
             // if so, we made the content empty, so add back the default text
             setActive(false)
+            emptyContent = true;
         }
-        
-        props.onChange(JSON.stringify(convertToRaw(state.getCurrentContent())));
+
+        if (props.onEmpty && emptyContent) {
+            props.onEmpty()
+        }
+        else {
+            props.onChange(JSON.stringify(convertToRaw(state.getCurrentContent())));
+        }
+
         setEditorState(state);
     }
 
     // NOTE: to simplify how this works, the logic for when each command comes into play
     //       is almost entirely in keyBindings
-    function handleKeyCommand(command : string, state : EditorState ) {
+    function handleKeyCommand(command: string, state: EditorState) {
         const selection = state.getSelection()
         const block = editorState.getCurrentContent().getBlockForKey(selection.getAnchorKey())
 
@@ -73,8 +82,8 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
             // internal style (for new input) is set to 'BOLD'
             onChange(RichUtils.toggleInlineStyle(state, 'BOLD'))
             return 'handled'
-        } 
-        
+        }
+
         if (command === 'make-list') {
             let modifiedContent = state.getCurrentContent()
 
@@ -91,7 +100,7 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
                 // remove first char
                 modifiedContent = Modifier.replaceText(state.getCurrentContent(), replacementRange, "")
             }
-            
+
             // modify state to reflect we deleted a character and then change current block to unordered list
             const modifiedState = RichUtils.toggleBlockType(EditorState.push(state, modifiedContent, 'delete-character'), 'unordered-list-item')
 
@@ -112,12 +121,12 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
             onChange(RichUtils.toggleBlockType(state, 'unstyled'))
             return 'handled'
         }
-  
+
         return 'not-handled'
     }
 
     // called by buttons (via onMouseDown) that act as controls for the field
-    function handleControlMouseDown(e : React.MouseEvent<HTMLElement>, modifiedState : EditorState) {
+    function handleControlMouseDown(e: React.MouseEvent<HTMLElement>, modifiedState: EditorState) {
         e.preventDefault()
         onChange(modifiedState)
     }
@@ -125,25 +134,25 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
     return (
         <div className={"richtext-field" + (props.isErroneous ? " error" : "")}>
             <div className="richtext-field-controls">
-                <button 
-                    onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleInlineStyle(editorState, 'BOLD'))} 
-                    onClick={(e) => {e.preventDefault()}}>
-                    <i className="bi bi-type-bold"/>
+                <button
+                    onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleInlineStyle(editorState, 'BOLD'))}
+                    onClick={(e) => { e.preventDefault() }}>
+                    <i className="bi bi-type-bold" />
                 </button>
-                <button 
-                    onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleBlockType(editorState, 'unordered-list-item'))} 
-                    onClick={(e) => {e.preventDefault()}}>
-                    <i className="bi bi-list-ul"/>
+                <button
+                    onMouseDown={(e) => handleControlMouseDown(e, RichUtils.toggleBlockType(editorState, 'unordered-list-item'))}
+                    onClick={(e) => { e.preventDefault() }}>
+                    <i className="bi bi-list-ul" />
                 </button>
             </div>
             <div className="richtext-field-input">
-                {!active && 
+                {!active &&
                     <span className="richtext-default-text">
                         {props.defaultText}
                     </span>
                 }
                 <ScrollWindow>
-                    <Editor editorState={editorState} onChange={onChange} handleKeyCommand={handleKeyCommand} keyBindingFn={keyBindings}/>
+                    <Editor editorState={editorState} onChange={onChange} handleKeyCommand={handleKeyCommand} keyBindingFn={keyBindings} />
                 </ScrollWindow>
             </div>
         </div>

--- a/client/src/components/atoms/RichTextField.tsx
+++ b/client/src/components/atoms/RichTextField.tsx
@@ -54,11 +54,14 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
         }
 
         let emptyContent = false;
-        // check if we are already typing (we are active) and state has no text
-        if (active && (!state.getCurrentContent().hasText() && state.getCurrentContent().getFirstBlock().getType() === 'unstyled')) {
-            // if so, we made the content empty, so add back the default text
-            setActive(false)
+        // check if state has no text
+        if ((!state.getCurrentContent().hasText() && state.getCurrentContent().getFirstBlock().getType() === 'unstyled')) {
             emptyContent = true;
+            // check if we are already typing (we are active) and 
+            if (active) {
+                // if so, we made the content empty, so add back the default text
+                setActive(false)
+            }
         }
 
         if (props.onEmpty && emptyContent) {

--- a/client/src/components/atoms/TagInput.tsx
+++ b/client/src/components/atoms/TagInput.tsx
@@ -16,7 +16,7 @@ const TagInput: FunctionComponent<TagInputProps> = (props: TagInputProps) => {
     return (
         <div className="tag-input">
             <div className="text-field-action-container">            
-                <TextFieldWithAction isErroneous={(!props.isErroneous)} onSubmit={(value:string) => props.onSubmit(value)} onChange={(value: string)=> props.onChange(value)} showAction={props.isErroneous} placeholder={props.placeholder} type="text" actionString={props.actionString} iconClassName="bi bi-arrow-return-left"></TextFieldWithAction>
+                <TextFieldWithAction isErroneous={props.isErroneous} onSubmit={(value:string) => props.onSubmit(value)} onChange={(value: string)=> props.onChange(value)} placeholder={props.placeholder} type="text" actionString={props.actionString} iconClassName="bi bi-arrow-return-left"></TextFieldWithAction>
             </div>
             <div className="tag-list">
                 {props.tagStrings.map((tag,index) => <div key={index} className="each-tag"><DeletableTag text={tag} onDelete={props.onDelete}/></div>)}

--- a/client/src/components/atoms/TagInput.tsx
+++ b/client/src/components/atoms/TagInput.tsx
@@ -6,18 +6,20 @@ interface TagInputProps {
     tagStrings: string[],
     onChange: (value: string) => boolean,
     onSubmit: (value: string) => void,
-    onDelete: (id: number) => void,
-    isErroneous: boolean
+    onDelete: (value: string) => void,
+    isErroneous: boolean,
+    placeholder: string,
+    actionString: string
 }
 
 const TagInput: FunctionComponent<TagInputProps> = (props: TagInputProps) => {
     return (
         <div className="tag-input">
             <div className="text-field-action-container">            
-                <TextFieldWithAction isErroneous={(!props.isErroneous)} onSubmit={(value:string) => props.onSubmit(value)} onChange={(value: string)=> props.onChange(value)} showAction={props.isErroneous} placeholder="Enter a new type" type="text" actionString="Add new type:" iconClassName="bi bi-arrow-return-left"></TextFieldWithAction>
+                <TextFieldWithAction isErroneous={(!props.isErroneous)} onSubmit={(value:string) => props.onSubmit(value)} onChange={(value: string)=> props.onChange(value)} showAction={props.isErroneous} placeholder={props.placeholder} type="text" actionString={props.actionString} iconClassName="bi bi-arrow-return-left"></TextFieldWithAction>
             </div>
             <div className="tag-list">
-                {props.tagStrings.map((tag,index) => <div key={index} className="each-tag"><DeletableTag id={index} text={tag} onDelete={(id)=> props.onDelete(id)}/></div>)}
+                {props.tagStrings.map((tag,index) => <div key={index} className="each-tag"><DeletableTag text={tag} onDelete={props.onDelete}/></div>)}
             </div>
                
         </div>

--- a/client/src/components/atoms/TagInput.tsx
+++ b/client/src/components/atoms/TagInput.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent } from "react";
 import DeletableTag from "./DeletableTag";
 import { TextFieldWithAction } from "./TextFieldWithAction";
 

--- a/client/src/components/atoms/TextField.tsx
+++ b/client/src/components/atoms/TextField.tsx
@@ -33,6 +33,7 @@ const TextField: FunctionComponent<TextFieldProps> = (props: TextFieldProps) => 
       onChange={props.onChange}
       disabled={props.isDisabled}
       autoComplete={props.autocompleteOff ? "off" : "on"}
+      onKeyDown={(e: React.KeyboardEvent) => { if (e.key == 'Enter') { e.preventDefault() } }}
     />
     {props.iconClassName && <i
       onClick={props.onIconClick ? props.onIconClick : () => {}}

--- a/client/src/components/atoms/TextFieldWithAction.tsx
+++ b/client/src/components/atoms/TextFieldWithAction.tsx
@@ -44,7 +44,7 @@ const TextFieldWithAction: FunctionComponent<TextFieldWithActionProps> = (props:
                     }}>
                     <div className={"action" + (props.isErroneous ? " error" : "")}>
                         <div className="action-string">{props.actionString}</div>
-                        <div className="action-value"><span className="action-value-text">{value}</span></div>
+                        <div className="action-value"><span className="action-value-text">{value.substring(0,40)}</span></div>
                     </div>
                 </a>
             </div>

--- a/client/src/components/atoms/TextFieldWithAction.tsx
+++ b/client/src/components/atoms/TextFieldWithAction.tsx
@@ -5,7 +5,6 @@ interface TextFieldWithActionProps {
   isErroneous: boolean,
   onChange: (value: string) => boolean,
   onSubmit: (value: string) => void,
-  showAction: boolean,
   placeholder: string,
   type: "text",
   actionString: string,
@@ -15,28 +14,29 @@ interface TextFieldWithActionProps {
 const TextFieldWithAction: FunctionComponent<TextFieldWithActionProps> = (props: TextFieldWithActionProps) => {
     const [value, setValue] = useState("");
     const onTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        e.preventDefault();
         const newValue = e.target.value;
+        
+        props.onChange(newValue);
         setValue(newValue);
     }
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if( e.key == 'Enter' ){
-            if (props.showAction){
-                if (value !== ""){
-                    props.onSubmit(value);
-                    setValue(""); 
-                }
+            e.preventDefault();
+            
+            if (value !== ""){
+                props.onSubmit(value);
+                setValue(""); 
             }
         }
     }
-    useEffect(() => {
-        props.onChange(value);
-    });
+    
     return (
     <div className="text-field-with-action">
         <div onKeyDown={handleKeyDown}>        
             <TextField input={value} isDisabled={false} isErroneous={props.isErroneous} onChange={onTextChange} name="text-field-action" placeholder={props.placeholder} type={props.type} iconClassName={props.iconClassName} ></TextField>
         </div>
-        {props.showAction && value!=="" && 
+        { value!=="" && 
             <div>
                 <a onClick={()=>{
                     if (value !== ""){props.onSubmit(value);}

--- a/client/src/components/atoms/TextFieldWithAction.tsx
+++ b/client/src/components/atoms/TextFieldWithAction.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState } from "react";
+import React, { FunctionComponent, useState } from "react";
 import { TextField } from "./TextField";
 
 interface TextFieldWithActionProps {

--- a/client/src/components/atoms/style/DeletableTag.scss
+++ b/client/src/components/atoms/style/DeletableTag.scss
@@ -1,5 +1,5 @@
 .deletable-tag{
     & .tag{
-        padding: 5px;
+        padding: 5px 10px;
     }
 }

--- a/client/src/components/atoms/style/ImageList.scss
+++ b/client/src/components/atoms/style/ImageList.scss
@@ -12,10 +12,8 @@
     position: absolute;
     margin: 0px 18px;
   }
-
   .img-wrapper {
-    height: 69px;
-    
+    height: 69px;    
     &-overlay {
       height: 59px;
       float: right;

--- a/client/src/components/atoms/style/ImageList.scss
+++ b/client/src/components/atoms/style/ImageList.scss
@@ -15,7 +15,6 @@
 
   .img-wrapper {
     height: 69px;
-    flex: unset;
     
     &-overlay {
       height: 59px;

--- a/client/src/components/atoms/style/ImageList.scss
+++ b/client/src/components/atoms/style/ImageList.scss
@@ -13,7 +13,7 @@
     margin: 0px 18px;
   }
   .img-wrapper {
-    height: 69px;    
+    height: 69px;
     &-overlay {
       height: 59px;
       float: right;

--- a/client/src/components/atoms/style/ImageList.scss
+++ b/client/src/components/atoms/style/ImageList.scss
@@ -12,8 +12,11 @@
     position: absolute;
     margin: 0px 18px;
   }
+
   .img-wrapper {
     height: 69px;
+    flex: unset;
+    
     &-overlay {
       height: 59px;
       float: right;

--- a/client/src/components/atoms/style/ImagePicker.scss
+++ b/client/src/components/atoms/style/ImagePicker.scss
@@ -23,7 +23,7 @@
   }
 
   &-preview {
-    margin: 0px 0px 14px 0px;
+    margin-bottom: 14px;
     height: 262px;
     width: 350px;
     display: flex;

--- a/client/src/components/atoms/style/ImagePicker.scss
+++ b/client/src/components/atoms/style/ImagePicker.scss
@@ -23,7 +23,7 @@
   }
 
   &-preview {
-    margin: 0px 0px 14px 8px;
+    margin: 0px 0px 14px 0px;
     height: 262px;
     width: 350px;
     display: flex;

--- a/client/src/components/atoms/style/ImagePicker.scss
+++ b/client/src/components/atoms/style/ImagePicker.scss
@@ -33,6 +33,7 @@
     img {
       height: 248px;
       width: 348px;
+      object-fit: cover;
     }
     .unselected {
       width: 100%;

--- a/client/src/components/atoms/style/ImagePicker.scss
+++ b/client/src/components/atoms/style/ImagePicker.scss
@@ -24,15 +24,15 @@
 
   &-preview {
     margin-bottom: 14px;
-    height: 262px;
-    width: 350px;
+    height: 248px;
+    width: 348px;
     display: flex;
 
     font-size: 24px;
 
     img {
-      height: 262px;
-      width: 350px;
+      height: 248px;
+      width: 348px;
     }
     .unselected {
       width: 100%;

--- a/client/src/components/atoms/style/RichTextField.scss
+++ b/client/src/components/atoms/style/RichTextField.scss
@@ -6,7 +6,7 @@
     background-color: $background;
     border: 1px solid $dark-border-color;
     box-sizing: border-box;
-    border-radius: 4px 4px 0 0;
+    border-radius: 4px;
 
     &.error {
         border-color: $error-color;
@@ -15,7 +15,7 @@
 
 .richtext-field-controls {
     width: 100%;
-    border-bottom: $dark-border;
+    border-bottom: $window-border;
 
     .error & {
         border-color: $error-color;
@@ -26,7 +26,7 @@
         height: 32px;
         background-color: transparent;
         border: none;
-        border-right: $dark-border;
+        border-right: $window-border;
 
         i {
             width: 12px;

--- a/client/src/components/atoms/style/RichTextField.scss
+++ b/client/src/components/atoms/style/RichTextField.scss
@@ -15,7 +15,7 @@
 
 .richtext-field-controls {
     width: 100%;
-    border-bottom: 1px solid $window-border-color;
+    border-bottom: $dark-border;
 
     .error & {
         border-color: $error-color;
@@ -26,7 +26,7 @@
         height: 32px;
         background-color: transparent;
         border: none;
-        border-right: 1px solid $window-border-color;
+        border-right: $dark-border;
 
         i {
             width: 12px;

--- a/client/src/components/atoms/style/RichTextField.scss
+++ b/client/src/components/atoms/style/RichTextField.scss
@@ -1,7 +1,6 @@
 .richtext-field {
     width: 484px;
     height: 252px;
-    margin-left: 500px;
     overflow: hidden;
 
     background-color: $background;

--- a/client/src/components/atoms/style/ScrollWindow.scss
+++ b/client/src/components/atoms/style/ScrollWindow.scss
@@ -3,7 +3,7 @@
   height: 100%;
 
   overflow-y: scroll;
-  border: $scroll-window-border;
+  border: $window-border;
   border-radius: 4px;
 
   // Custom scrollbar only shows on Chrome, Edge, Safari and Opera

--- a/client/src/components/atoms/style/SearchableDropdown.scss
+++ b/client/src/components/atoms/style/SearchableDropdown.scss
@@ -42,7 +42,7 @@
   .no-items-found {
     width: 100%;
 
-    border: $scroll-window-border;
+    border: $window-border;
     border-radius: 4px;
     padding: 14px;
 

--- a/client/src/components/atoms/style/TagInput.scss
+++ b/client/src/components/atoms/style/TagInput.scss
@@ -1,11 +1,11 @@
 .tag-input{
-    .text-field-action-container{
-        margin-bottom: 10px;
-    }
     .tag-list{
+        margin-top: 10px;
         display:flex;
+        flex-wrap: wrap;
     }
     .deletable-tag{
+        margin-top: 5px;
         margin-right: 10px;
     }
 }

--- a/client/src/components/atoms/style/TextField.scss
+++ b/client/src/components/atoms/style/TextField.scss
@@ -7,7 +7,7 @@
 
   &-input {
     align-self: left;
-    border: 1px solid $textfield-input-border;
+    border: 1px solid $dark-border-color;
     box-sizing: border-box;
     border-radius: 4px;
     padding-left: 12px;
@@ -17,7 +17,7 @@
 
     &:focus {
       outline-width: 0;
-      border: 1px solid $soft-black;
+      border-color: $tpc-green;
     }
 
     &:disabled {

--- a/client/src/components/atoms/style/TextFieldWithAction.scss
+++ b/client/src/components/atoms/style/TextFieldWithAction.scss
@@ -1,26 +1,21 @@
 .text-field-with-action{
     @include text();
     & .text-field-input {
-        width: 300px;
+        width: 100%;
         height:40px;
-        margin-bottom: 10px;
-        border: 1px solid#333333;
-        &.error {
-            border: 1px solid $input-error;
-        }
     }
     .text-field i {
         margin-left: -30px;
     }
     .action{
+        margin-top: 10px;
         display: inline-flex;
         &.error {
-            border: 1px solid $input-error;
-            padding:5px;
+            border: 1px solid $error-faded-color;
         }
         border: 1px solid #e9e9e9;
         border-radius: 4px;
-        width: 300px;
+        width: 100%;
         height:40px;
         line-height: 40px;
         padding-left: 19px;

--- a/client/src/components/atoms/style/Tooltip.scss
+++ b/client/src/components/atoms/style/Tooltip.scss
@@ -1,4 +1,6 @@
 .tooltip-inner {
+    @include normal-text;
+    padding: 10px 20px;
     background-color: $tooltip-background-color;
     color: $tooltip-text-color;
     text-align: left;

--- a/client/src/components/examples/RequestGroupFormContainer.tsx
+++ b/client/src/components/examples/RequestGroupFormContainer.tsx
@@ -1,0 +1,53 @@
+import { bindActionCreators, Dispatch } from "redux"
+import { gql, useQuery } from "@apollo/client";
+import React, { FunctionComponent, useState } from "react";
+import { connect } from "react-redux";
+
+import { loadRequestGroups } from '../../data/actions'
+import RequestGroup from "../../data/types/requestGroup"
+import RequestGroupForm from "../organisms/RequestGroupForm";
+import { RootState } from '../../data/reducers'
+
+
+interface DispatchProps {
+  loadRequestGroups: typeof loadRequestGroups,
+}
+
+type Props = DispatchProps
+
+
+const RequestGroupFormContainer: FunctionComponent<Props> = (props: Props) => {
+  const [show, setShow] = useState(true);
+
+  const query = gql`
+  {
+    requestGroups {
+      _id
+      name
+    }
+  }`
+
+  useQuery(query, {
+    onCompleted: (data: { requestGroups: Array<RequestGroup> }) => {
+      // Clone state.data because sort occurs in-place.
+      console.log("All request groups:")
+      console.log(data.requestGroups)
+      props.loadRequestGroups(data.requestGroups);
+    },
+  });
+
+  return (<>{show && <RequestGroupForm handleClose={() => setShow(false)} operation="edit" />}</>)
+
+};
+
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
+  return bindActionCreators(
+    {
+      loadRequestGroups,
+    },
+    dispatch
+  );
+};
+
+export default connect<Record<string, unknown>, DispatchProps, Record<string, unknown>, RootState>(null, mapDispatchToProps)(RequestGroupFormContainer);
+

--- a/client/src/components/examples/TagInputContainer.tsx
+++ b/client/src/components/examples/TagInputContainer.tsx
@@ -2,41 +2,41 @@ import React, { FunctionComponent, useState } from "react";
 import { TagInput } from "../atoms/TagInput";
 
 interface TagInputContainerProps {
-    name:string
+    name: string
 }
 
 const TagInputContainer: FunctionComponent<TagInputContainerProps> = (props: TagInputContainerProps) => {
-    const [ tagStringsList, setTagStringsList ] = useState<string[]>(["Diapers"]); 
-    const [ validInput, setValidInput ] = useState(true);
+    const [tagStringsList, setTagStringsList] = useState<string[]>(["Diapers"]);
+    const [validInput, setValidInput] = useState(true);
 
     const onChange = (value: string) => {
-        if (!isValidInput(value)){
-            setValidInput(false); 
+        if (!isValidInput(value)) {
+            setValidInput(false);
             return false
-        } else{
+        } else {
             setValidInput(true);
             return true
         }
     }
     const onSubmit = (value: string) => {
-        const input:string = value.trim();
+        const input: string = value.trim();
         setTagStringsList([...tagStringsList, input]);
     }
-    const onDelete = (id:number) => {
-        setTagStringsList(tagStringsList.filter((_,i) => i !== id));
+    const onDelete = (value: string) => {
+        setTagStringsList(tagStringsList.filter((tagString) => tagString !== value));
     }
-    const isValidInput = (value:string) => {
+    const isValidInput = (value: string) => {
         // could be replaced with any validation logic
-        const input:string = value.trim();
-        if (tagStringsList.includes(input)){
+        const input: string = value.trim();
+        if (tagStringsList.includes(input)) {
             return false;
         }
         return true;
     };
 
     return (
-        <div style={{marginLeft: "20px", marginTop: "20px"}}>        
-            <TagInput tagStrings={tagStringsList} onSubmit={(value)=> onSubmit(value)} onChange={(value)=>onChange(value)} onDelete={(id)=>onDelete(id)} isErroneous={validInput}></TagInput>
+        <div style={{ marginLeft: "20px", marginTop: "20px" }}>
+            <TagInput tagStrings={tagStringsList} onSubmit={(value) => onSubmit(value)} onChange={(value) => onChange(value)} onDelete={(id) => onDelete(id)} isErroneous={validInput} placeholder="this is a placeholder" actionString="action:" ></TagInput>
         </div>
     );
 };

--- a/client/src/components/examples/TagInputContainer.tsx
+++ b/client/src/components/examples/TagInputContainer.tsx
@@ -5,7 +5,7 @@ interface TagInputContainerProps {
     name: string
 }
 
-const TagInputContainer: FunctionComponent<TagInputContainerProps> = (props: TagInputContainerProps) => {
+const TagInputContainer: FunctionComponent<TagInputContainerProps> = () => {
     const [tagStringsList, setTagStringsList] = useState<string[]>(["Diapers"]);
     const [validInput, setValidInput] = useState(true);
 

--- a/client/src/components/molecules/FormItem.tsx
+++ b/client/src/components/molecules/FormItem.tsx
@@ -8,6 +8,7 @@ interface Props {
     isDisabled: boolean;
     inputComponent: React.ReactNode;
     tooltipText?: string;
+    instructions?: string;
 }
 
 const FormItem: FunctionComponent<Props> = (props: Props) => {
@@ -18,10 +19,15 @@ const FormItem: FunctionComponent<Props> = (props: Props) => {
             <div className="form-item-top">
                 <span className={props.isDisabled ? "form-item-disabled" : undefined}>
                     {props.formItemName}
-                    {props.tooltipText && <Tooltip tooltipText={props.tooltipText}/>}
+                    {props.tooltipText && <Tooltip tooltipText={props.tooltipText} />}
                 </span>
                 {isError && <span className="form-item-error-text">{props.errorString}</span>}
             </div>
+            {props.instructions &&
+                <div className="form-item-instructions">
+                    {props.instructions}
+                </div>
+            }
             <div className="form-item-bottom">
                 {props.inputComponent}
                 {isError && <i className="form-item-error-icon bi bi-exclamation-circle alert-icon"></i>}

--- a/client/src/components/molecules/style/FormItem.scss
+++ b/client/src/components/molecules/style/FormItem.scss
@@ -1,6 +1,4 @@
 .form-item {
-    // width: 350px;
-
     &-disabled {
         color: $disabled-text;
     }
@@ -8,7 +6,6 @@
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-        // width: 300px;
     }
     &-instructions {
         color: $disabled-text;
@@ -19,8 +16,9 @@
     }
     &-bottom {
         text-align: left;
-        position: relative;
         margin-top: 11px;
+        display: flex;
+        flex-direction: row;
     }
     &-error-text {
         color: $input-error;
@@ -33,7 +31,5 @@
         margin-left: 10px;
         color: $input-error;
         font-size: 22px;
-        position: absolute;
-        margin-top: 5px;
     }
 }

--- a/client/src/components/molecules/style/FormItem.scss
+++ b/client/src/components/molecules/style/FormItem.scss
@@ -1,25 +1,33 @@
 .form-item {
-    width: 350px;
+    // width: 350px;
 
     &-disabled {
         color: $disabled-text;
     }
     &-top {
-        margin-bottom: 11px;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-        width: 300px;
+        // width: 300px;
+    }
+    &-instructions {
+        color: $disabled-text;
+        font-size: 14px;
+        line-height: 15px;
+        text-align: left;
+        margin-top: 8px;
     }
     &-bottom {
         text-align: left;
         position: relative;
+        margin-top: 11px;
     }
     &-error-text {
         color: $input-error;
         font-size: 12px;
         vertical-align: bottom;
         padding-top: 5px;
+        text-align: right;
     }
     &-error-icon {
         margin-left: 10px;

--- a/client/src/components/organisms/FormModal.tsx
+++ b/client/src/components/organisms/FormModal.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react';
 import CommonModal from "./Modal"
 
 interface Props {
+  class: string;
   title: string;
   show: boolean;
   handleClose(): void;
@@ -12,7 +13,7 @@ interface Props {
 
 const FormModal: FunctionComponent<Props> = (props: Props) => {
   return (
-    <CommonModal customClose class="modal-admin" size={props.size} show={props.show} handleClose={props.handleClose} header={<div className={`modal-admin-header-title-${props.size}`}>
+    <CommonModal customClose class={"modal-admin " + props.class} size={props.size} show={props.show} handleClose={props.handleClose} header={<div className={`modal-admin-header-title-${props.size}`}>
       {props.title}{props.extraHeader}
     </div>}>
       <>

--- a/client/src/components/organisms/LogoModal.tsx
+++ b/client/src/components/organisms/LogoModal.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const LogoModal: FunctionComponent<Props> = (props: Props) => {
   return (
-    <CommonModal class="modal" size="default" show={props.show} handleClose={props.handleClose}>
+    <CommonModal class="logo-modal" size="default" show={props.show} handleClose={props.handleClose}>
       <div className="pc-icon">
         <img src={tpcLeaf}></img>
       </div>

--- a/client/src/components/organisms/Modal.tsx
+++ b/client/src/components/organisms/Modal.tsx
@@ -24,10 +24,10 @@ const CommonModal: FunctionComponent<Props> = (props: Props) => {
   }
 
   return (
-    <Modal show={props.show} onHide={props.handleClose} centered={true} className={props.class} size={props.size === "default" ? undefined : modalSize} dialogClassName="border-radius-12">
-      <Modal.Header closeButton={!props.customClose} className={`${props.class}-header` + (props.size === "default" ? "" : `-${props.size}`)} >{props.header}{props.customClose && <i onClick={props.handleClose} className={`bi bi-x ${props.class}-header close` + (props.size === "default" ? "" : ` ${props.size}`)}></i>}</Modal.Header>
-      <Modal.Body className={`${props.class}-body`} >{props.children}</Modal.Body>
-      <Modal.Footer />
+    <Modal show={props.show} onHide={props.handleClose} centered={true} className={"common-modal " + props.class} size={props.size === "default" ? undefined : modalSize} >
+        <Modal.Header closeButton={!props.customClose} className={`${props.class}-header` + (props.size === "default" ? "" : `-${props.size}`)} >{props.header}{props.customClose && <i onClick={props.handleClose} className={`bi bi-x ${props.class}-header close` + (props.size === "default" ? "" : ` ${props.size}`)}></i>}</Modal.Header>
+        <Modal.Body className={`${props.class}-body`} >{props.children}</Modal.Body>
+        <Modal.Footer />
     </Modal>
   );
 }

--- a/client/src/components/organisms/Modal.tsx
+++ b/client/src/components/organisms/Modal.tsx
@@ -26,7 +26,7 @@ const CommonModal: FunctionComponent<Props> = (props: Props) => {
   return (
     <Modal show={props.show} onHide={props.handleClose} centered={true} className={props.class} size={props.size === "default" ? undefined : modalSize} dialogClassName="border-radius-12">
       <Modal.Header closeButton={!props.customClose} className={`${props.class}-header` + (props.size === "default" ? "" : `-${props.size}`)} >{props.header}{props.customClose && <i onClick={props.handleClose} className={`bi bi-x ${props.class}-header close` + (props.size === "default" ? "" : ` ${props.size}`)}></i>}</Modal.Header>
-      <Modal.Body>{props.children}</Modal.Body>
+      <Modal.Body className={`${props.class}-body`} >{props.children}</Modal.Body>
       <Modal.Footer />
     </Modal>
   );

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -42,7 +42,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   const [image, setImage] = useState("")
   const [requestTypesToIdMap, setRequestTypesToIdMap] = useState(new Map<string, string>())
   const [requestTypeNames, setRequestTypeNames] = useState<Array<string>>([])
-  // const [inputRequestTypeName, setInputRequestTypeName] = useState("")
   const [nameError, setNameError] = useState("")
   const [descriptionError, setDescriptionError] = useState("")
   const [imageError, setImageError] = useState("")

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -270,7 +270,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
             <div className="tag-input-form-item">
               <FormItem
                 formItemName="Item Types"
-                instructions="If no types are applicable,  create a universal type such as “One Size”"
+                instructions="If no types are applicable, create a universal type such as “One Size”"
                 errorString={requestTypesError}
                 isDisabled={false}
                 tooltipText="Types describe more specific information about a request, such as size, capacity, or intended child age."

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -1,5 +1,4 @@
 import { bindActionCreators, Dispatch } from "redux"
-import { convertFromRaw, EditorState } from 'draft-js';
 import { gql, useQuery } from "@apollo/client";
 import React, { FunctionComponent, useState } from "react";
 import { connect } from "react-redux";

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -235,12 +235,15 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   }
 
 
+  const formTitle = props.operation === "create" ? "Create Request Group" : "Edit Request Group";
+  const formButtonText = props.operation === "create" ? "Create request group" : "Edit request group";
+
   return <div className="request-group-form">
     <FormModal
       class="request-group-form-modal"
       show={true}
       handleClose={handleClose}
-      title={props.operation === "create" ? "Create Request Group" : "Edit Request Group"}
+      title={formTitle}
       size="large">
       {showAlertDialog &&
         <AlertDialog
@@ -326,7 +329,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
         </div>
         <div className="request-group-form-modal-footer">
           <Button
-            text={props.operation === "create" ? "Create request group" : "Edit request group"}
+            text={formButtonText}
             copyText=""
           />
         </div>

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -93,18 +93,20 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   }
 
   /* Functions for RequestGroup's Name*/
-  const getNameError = (name: string): string => {
+  const updateNameError = (name: string): string => {
+    let error = ""
     if (name.length === 0) {
-      return "Please enter a group name";
+      error = "Please enter a group name";
     }
     if (name.length > 20) {
-      return "Group name cannot exceed 20 characters";
+      error = "Group name cannot exceed 20 characters";
     }
     if (props.requestGroups.find((requestGroup) => requestGroup.name === name && requestGroup._id !== props.requestGroupId)) {
-      return "There is already a group with this name";
+      error = "There is already a group with this name";
     }
 
-    return "";
+    setNameError(error)
+    return error;
   }
 
   const onNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -113,29 +115,41 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
 
     setChangeMade(true);
     setName(newName);
-    setNameError(getNameError(newName))
+    updateNameError(newName)
   }
 
   /* Functions for RequestGroup's RequestTypes */
 
-  const getInputRequestTypeNameError = (inputRequestTypeName: string): string => {
+  const updateInputRequestTypeNameError = (inputRequestTypeName: string): string => {
+    let error = ""
     if (requestTypeNames.find(requestTypeName => requestTypeName === inputRequestTypeName)) {
-      return "There is already a type with this name";
+      error = "There is already a type with this name";
     }
     else if (inputRequestTypeName.length > 40) {
-      return "Type name cannot exceed 40 characters";
+      error = "Type name cannot exceed 40 characters";
     }
-    return "";
+
+    setRequestTypesError(error);
+    return error;
+  }
+
+  const updateRequestTypeNamesError = (requestTypes: Array<string>): string => {
+    let error = ""
+    if (requestTypes.length === 0) {
+      error = "Please create at least 1 type";
+    }
+
+    setRequestTypesError(error);
+    return error;
   }
 
   const onAddRequestType = (newRequestTypeName: string) => {
-    const error = getInputRequestTypeNameError(newRequestTypeName);
+    const error = updateInputRequestTypeNameError(newRequestTypeName);
 
     if (error === "") {
       setRequestTypeNames(requestTypeNames.concat([newRequestTypeName]));
     }
     setChangeMade(true);
-    setRequestTypesError(error);
   }
 
   const onDeleteRequestType = (targetRequestTypeName: string) => {
@@ -143,36 +157,30 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
 
     setChangeMade(true);
     setRequestTypeNames(newRequestTypeNames);
-    setRequestTypesError(getRequestTypeNamesError(newRequestTypeNames))
+    updateRequestTypeNamesError(newRequestTypeNames)
   }
 
   const onInputRequestTypeNameChange = (requestTypeName: string) => {
     setChangeMade(true);
-    setRequestTypesError(getInputRequestTypeNameError(requestTypeName))
+    updateInputRequestTypeNameError(requestTypeName)
     return true;
   }
 
-  const getRequestTypeNamesError = (requestTypes: Array<string>): string => {
-    if (requestTypes.length === 0) {
-
-      return "Please create at least 1 type";
-    }
-    return "";
-  }
-
   /* Functions for RequestGroup's Description */
-  const getDescriptionError = (description: string) => {
+  const updateDescriptionError = (description: string) => {
+    let error = ""
     if (!description) {
-      return "Please enter a description";
+      error = "Please enter a description";
     }
 
-    return "";
+    setDescriptionError(error)
+    return error;
   }
 
   const onDescriptionChange = (newDescription: string) => {
     setChangeMade(true);
     setDescription(newDescription)
-    setDescriptionError(getDescriptionError(description))
+    updateDescriptionError(description)
   }
 
   const onDecriptionEmpty = () => {
@@ -180,16 +188,19 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   }
 
   /* Functions for RequestGroup's Image */
-  const getImageError = (image: string) => {
+  const updateImageError = (image: string) => {
+    let error = ""
     if (image === "") {
-      return "Please select an image";
+      error ="Please select an image";
     }
-    return "";
+
+    setImageError(error)
+    return error;
   }
 
   const onImageChange = (newImage: string) => {
     setChangeMade(true);
-    setImageError(getImageError(newImage))
+    updateImageError(newImage)
     if (images.find((imageUrl) => imageUrl === newImage)) {
       setImage(newImage)
     }
@@ -197,21 +208,14 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const tempNameError = getNameError(name);
-    const tempDescriptionError = getDescriptionError(description);
-    const tempImageError = getImageError(image);
-    const tempRequestTypesError = getRequestTypeNamesError(requestTypeNames);
+    const tempNameError = updateNameError(name);
+    const tempDescriptionError = updateDescriptionError(description);
+    const tempImageError = updateImageError(image);
+    const tempRequestTypesError = updateRequestTypeNamesError(requestTypeNames);
 
     if (!tempNameError && !tempDescriptionError && !tempImageError && !tempRequestTypesError) {
       // do mutation
       props.handleClose()
-    }
-    else {
-      setNameError(tempNameError);
-      setDescriptionError(tempDescriptionError);
-      setImageError(tempImageError);
-
-      setRequestTypesError(tempRequestTypesError);
     }
   }
 

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -100,6 +100,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     });
   }
 
+  /* Functions for RequestGroup's Name*/
   const getNameError = (name: string): string => {
     if (name.length === 0) {
       return "Please enter a group name";
@@ -114,6 +115,17 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     return "";
   }
 
+  const onNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    const newName: string = event.target.value;
+
+    setChangeMade(true);
+    setName(newName);
+    setNameError(getNameError(newName))
+  }
+
+  /* Functions for RequestGroup's RequestTypes */
+
   const getInputRequestTypeNameError = (inputRequestTypeName: string): string => {
     if (requestTypeNames.find(requestTypeName => requestTypeName === inputRequestTypeName)) {
       return "There is already a type with this name";
@@ -122,43 +134,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
       return "Type name cannot exceed 40 characters";
     }
     return "";
-  }
-
-  const getRequestTypeNamesError = (requestTypes: Array<string>): string => {
-    if (requestTypes.length === 0) {
-
-      return "Please create at least 1 type";
-    }
-    return "";
-  }
-
-  const getDescriptionError = (description: string) => {
-    if (!description) {
-      return "Please enter a description";
-    }
-
-    const editorState = EditorState.createWithContent(convertFromRaw(JSON.parse(description)))
-    if (!editorState.getCurrentContent().hasText()) {
-      return "Please enter a description";
-    }
-
-    return "";
-  }
-
-  const getImageError = (image: string) => {
-    if (image === "") {
-      return "Please select an image";
-    }
-    return "";
-  }
-
-  const onNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    event.preventDefault();
-    const newName: string = event.target.value;
-
-    setChangeMade(true);
-    setName(newName);
-    setNameError(getNameError(newName))
   }
 
   const onAddRequestType = (newRequestTypeName: string) => {
@@ -185,10 +160,40 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     return true;
   }
 
+  const getRequestTypeNamesError = (requestTypes: Array<string>): string => {
+    if (requestTypes.length === 0) {
+
+      return "Please create at least 1 type";
+    }
+    return "";
+  }
+
+  /* Functions for RequestGroup's Description */
+  const getDescriptionError = (description: string) => {
+    if (!description) {
+      return "Please enter a description";
+    }
+
+    const editorState = EditorState.createWithContent(convertFromRaw(JSON.parse(description)))
+    if (!editorState.getCurrentContent().hasText()) {
+      return "Please enter a description";
+    }
+
+    return "";
+  }
+
   const onDescriptionChange = (newDescription: string) => {
     setChangeMade(true);
     setDescription(newDescription)
     setDescriptionError(getDescriptionError(description))
+  }
+
+  /* Functions for RequestGroup's Image */
+  const getImageError = (image: string) => {
+    if (image === "") {
+      return "Please select an image";
+    }
+    return "";
   }
 
   const onImageChange = (newImage: string) => {

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -15,7 +15,6 @@ import { RootState } from '../../data/reducers'
 import { TagInput } from '../atoms/TagInput'
 import { TextField } from '../atoms/TextField'
 import { upsertRequestGroup } from '../../data/actions'
-// import Tooltip from '../atoms/Tooltip'
 
 interface StateProps {
   requestGroups: Array<RequestGroup>
@@ -75,7 +74,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   }`
 
   if (props.requestGroupId) {
-    const { loading, error } = useQuery(requestGroupQuery, {
+    useQuery(requestGroupQuery, {
       variables: { id: props.requestGroupId, },
       onCompleted: (data: { requestGroup: RequestGroup }) => {
         const res: RequestGroup = JSON.parse(JSON.stringify(data.requestGroup)); // deep-copy since data object is frozen
@@ -256,6 +255,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
                 formItemName="Group Name"
                 errorString={nameError}
                 isDisabled={false}
+                tooltipText="Groups describe the overall category of an item, such as stroller, crib, or bed."
                 inputComponent={<TextField
                   name="name"
                   placeholder="Enter a group name"
@@ -274,6 +274,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
                 instructions="If no types are applicable,  create a universal type such as “One Size”"
                 errorString={requestTypesError}
                 isDisabled={false}
+                tooltipText="Types describe more specific information about a request, such as size, capacity, or intended child age."
                 inputComponent={
                   <TagInput
                     tagStrings={requestTypeNames}

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -204,7 +204,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     const tempImageError = getImageError(image);
     const tempRequestTypesError = getRequestTypeNamesError(requestTypeNames);
 
-    if (tempNameError === "" && tempDescriptionError === "" && tempImageError === "" && tempRequestTypesError === "") {
+    if (!tempNameError && !tempDescriptionError && !tempImageError && !tempRequestTypesError) {
       // do mutation
 
       props.handleClose()

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -186,11 +186,13 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   }
 
   const onDescriptionChange = (newDescription: string) => {
+    setChangeMade(true);
     setDescription(newDescription)
     setDescriptionError(getDescriptionError(description))
   }
 
   const onImageChange = (newImage: string) => {
+    setChangeMade(true);
     setImageError(getImageError(newImage))
     if (images.find((imageUrl) => imageUrl === newImage)) {
       setImage(newImage)

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -1,6 +1,6 @@
 import { bindActionCreators, Dispatch } from "redux"
 import { convertFromRaw, EditorState } from 'draft-js';
-import { gql, useMutation, useQuery } from "@apollo/client";
+import { gql, useQuery } from "@apollo/client";
 import React, { FunctionComponent, useState } from "react";
 import { connect } from "react-redux";
 

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -1,0 +1,266 @@
+import { bindActionCreators, Dispatch } from "redux"
+import { gql, useMutation, useQuery } from "@apollo/client";
+import React, { FunctionComponent, useState } from "react";
+import { connect } from "react-redux";
+
+import AlertDialog from '../atoms/AlertDialog'
+import CommonModal from './Modal'
+import FormItem from '../molecules/FormItem'
+import RequestGroup from '../../data/types/requestGroup'
+import { RootState } from '../../data/reducers'
+import { TagInput } from '../atoms/TagInput'
+import { TextField } from '../atoms/TextField'
+import { upsertRequestGroup } from '../../data/actions'
+// import Tooltip from '../atoms/Tooltip'
+
+interface StateProps {
+  requestGroups: Array<RequestGroup>
+}
+
+interface DispatchProps {
+  upsertRequestGroup: typeof upsertRequestGroup
+}
+
+
+type Props = StateProps
+  & DispatchProps
+  & {
+    show: boolean,
+    handleClose: () => void,
+    requestGroupId?: string,
+    operation: "create" | "edit"
+  };
+
+const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
+  // const [initialRequestGroup, setInitialRequestGroup] = useState<RequestGroup | null>(null)
+  const [showAlertDialog, setShowAlertDialog] = useState(false)
+  const [changeMade, setChangeMade] = useState(false)
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [image, setImage] = useState("")
+  const [requestTypesToIdMap, setRequestTypesToIdMap] = useState(new Map<string, string>())
+  const [requestTypeNames, setRequestTypeNames] = useState<Array<string>>([])
+  // const [inputRequestTypeName, setInputRequestTypeName] = useState("")
+  const [nameError, setNameError] = useState("")
+  const [descriptionError, setDescriptionError] = useState("")
+  const [imageError, setImageError] = useState("")
+  const [requestTypesError, setRequestTypesError] = useState("")
+
+
+  const requestGroupQuery = gql`
+  {
+    query FetchRequestGroup($id: ID!) {
+      requestGroup(id: $id) {
+        id
+        name
+        description
+        image
+        requestTypes {
+          id
+          name
+          deleted
+        }
+      }
+    }
+  }`
+
+  // id: ID
+  // name: String
+  // description: String
+  // image: String
+  // requestTypes: [ID]
+
+  if (props.requestGroupId) {
+    const { loading, error } = useQuery(requestGroupQuery, {
+      variables: { id: props.requestGroupId, },
+      onCompleted: (data: { requestGroup: RequestGroup }) => {
+        const res: RequestGroup = JSON.parse(JSON.stringify(data.requestGroup)); // deep-copy since data object is frozen
+
+        setName(res.name ? res.name : "")
+        setDescription(res.description ? res.description : "")
+        setImage(res.image ? res.image : "")
+
+        res.requestTypes?.forEach((requestType) => {
+          if (requestType.name && requestType._id) {
+            setRequestTypesToIdMap(requestTypesToIdMap.set(requestType.name, requestType._id))
+          }
+        })
+
+        setRequestTypeNames(
+          res.requestTypes ?
+            res.requestTypes
+              .filter((requestType) => requestType.name)
+              .map((requestType) => requestType.name as string)
+            : []
+        )
+      }
+    });
+  }
+
+  const getNameError = (name: string): string => {
+    if (name.length === 0) {
+      return "Please enter a group name";
+    }
+    if (name.length > 20) {
+      return "Group name cannot exceed 20 characters";
+    }
+    if (props.requestGroups.find((requestGroup) => requestGroup.name === name && requestGroup._id !== props.requestGroupId)) {
+      return "There is already a group with this name";
+    }
+
+    return "";
+  }
+
+  const getInputRequestTypeNameError = (requestTypeName: string): string => {
+    if (requestTypeNames.find(requestTypeName => requestTypeName === requestTypeName)) {
+      return "There is already a type with this name";
+    }
+    else if (requestTypeName.length > 40) {
+      return "Type name cannot exceed 40 characters";
+    }
+    return "";
+  }
+
+  const getRequestTypeNamesError = (requestTypes: Array<string>): string => {
+    if (requestTypes.length === 0) {
+      return "Please create at least 1 type";
+    }
+    return "";
+  }
+
+  const onNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newName: string = event.target.value;
+
+    setChangeMade(true);
+    setName(newName);
+    setNameError(getNameError(newName))
+  }
+
+  const onAddRequestType = (newRequestTypeName: string) => {
+    const error = getInputRequestTypeNameError(newRequestTypeName);
+
+    if (error === "") {
+      setRequestTypeNames(requestTypeNames.concat([newRequestTypeName]));
+    }
+    setChangeMade(true);
+    setRequestTypesError(error);
+  }
+
+  const onDeleteRequestType = (targetRequestTypeName: string) => {
+    const newRequestTypeNames = requestTypeNames.filter((requestTypeName) => requestTypeName !== targetRequestTypeName);
+
+    setChangeMade(true);
+    setRequestTypeNames(newRequestTypeNames);
+    setRequestTypesError(getRequestTypeNamesError(newRequestTypeNames))
+  }
+
+  const onInputRequestTypeNameChange = (requestTypeName: string) => {
+    setChangeMade(true);
+    // setInputRequestTypeName(requestTypeName);
+    setRequestTypesError(getInputRequestTypeNameError(requestTypeName))
+    return true;
+  }
+
+  const onSubmit = () => {
+
+  }
+
+  const handleClose = () => {
+    if (changeMade) {
+      setShowAlertDialog(true);
+    }
+    else {
+      props.handleClose();
+    }
+  }
+
+
+  const formTitle = props.operation === "create" ? "Create Request Group" : "Edit Request Group";
+  return <div className="request-group-form">
+    {showAlertDialog &&
+      <AlertDialog
+        dialogText="You have unsaved changes to this group."
+        onExit={() => props.handleClose()}
+        onStay={() => { setShowAlertDialog(false) }} />
+    }
+    <CommonModal
+      class="request-group-form-modal"
+      show={true}
+      handleClose={handleClose}
+      header={<h1>{formTitle}</h1>}
+      size="large">
+      <form>
+        <div className="request-group-form-modal-content">
+          <div className="request-group-form-modal-panel" id="left">
+            <FormItem
+              formItemName="Group Name"
+              errorString={nameError}
+              isDisabled={false}
+              inputComponent={<TextField
+                name="name"
+                placeholder="Enter a group name"
+                type="text"
+                input={name}
+                isDisabled={false}
+                isErroneous={nameError !== ""}
+                onChange={onNameChange}
+              />
+              }
+            />
+          </div>
+          <FormItem
+            formItemName="Item Types"
+            errorString={requestTypesError}
+            isDisabled={false}
+            inputComponent={<TagInput
+              tagStrings={requestTypeNames}
+              placeholder="Enter a new type"
+              actionString="Add new type:"
+              isErroneous={requestTypesError !== ""}
+              onChange={onInputRequestTypeNameChange}
+              onSubmit={onAddRequestType}
+              onDelete={onDeleteRequestType}
+            />
+            }
+          />
+          <FormItem
+            formItemName="Description & Requirements"
+            errorString={nameError}
+            isDisabled={false}
+            inputComponent={<TextField
+              name="name"
+              placeholder="Enter a group name"
+              type="text"
+              input={name}
+              isDisabled={false}
+              isErroneous={nameError !== ""}
+              onChange={onNameChange}
+            />
+            }
+          />
+        </div>
+        <div className="request-group-form-modal-panel" id="right">
+
+        </div>
+        </div>
+      </form>
+    </CommonModal>
+  </div >
+};
+
+const mapStateToProps = (store: RootState): StateProps => {
+  return {
+    requestGroups: store.requestGroups.data,
+  };
+};
+
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {
+  return bindActionCreators(
+    {
+      upsertRequestGroup
+    },
+    dispatch
+  );
+};
+
+export default connect<StateProps, DispatchProps, Record<string, unknown>, RootState>(mapStateToProps, mapDispatchToProps)(RequestGroupForm);

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -40,7 +40,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [image, setImage] = useState("")
-  const [requestTypesToIdMap, setRequestTypesToIdMap] = useState(new Map<string, string>())
   const [requestTypeNames, setRequestTypeNames] = useState<Array<string>>([])
   const [nameError, setNameError] = useState("")
   const [descriptionError, setDescriptionError] = useState("")
@@ -82,12 +81,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
         setName(res.name ? res.name : "")
         setDescription(res.description ? res.description : "")
         setImage(res.image ? res.image : "")
-
-        res.requestTypes?.forEach((requestType) => {
-          if (requestType.name && requestType._id) {
-            setRequestTypesToIdMap(requestTypesToIdMap.set(requestType.name, requestType._id))
-          }
-        })
 
         setRequestTypeNames(
           res.requestTypes ?
@@ -174,11 +167,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
       return "Please enter a description";
     }
 
-    const editorState = EditorState.createWithContent(convertFromRaw(JSON.parse(description)))
-    if (!editorState.getCurrentContent().hasText()) {
-      return "Please enter a description";
-    }
-
     return "";
   }
 
@@ -186,6 +174,10 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     setChangeMade(true);
     setDescription(newDescription)
     setDescriptionError(getDescriptionError(description))
+  }
+
+  const onDecriptionEmpty = () => {
+    onDescriptionChange("")
   }
 
   /* Functions for RequestGroup's Image */
@@ -213,7 +205,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
 
     if (!tempNameError && !tempDescriptionError && !tempImageError && !tempRequestTypesError) {
       // do mutation
-
       props.handleClose()
     }
     else {
@@ -308,6 +299,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
                     initialContent={initialRequestGroup && initialRequestGroup.description ? initialRequestGroup.description : ""}
                     defaultText="Enter group description here"
                     onChange={onDescriptionChange}
+                    onEmpty={onDecriptionEmpty}
                     isErroneous={descriptionError !== ""}
                   />
                 }

--- a/client/src/components/organisms/style/Modal.scss
+++ b/client/src/components/organisms/style/Modal.scss
@@ -1,5 +1,5 @@
-.border-radius-12 div {
-  border-radius: 12px !important;
+.common-modal .modal-content {
+  border-radius: 12px;
 }
 
 .modal-admin {
@@ -30,7 +30,7 @@
     &-title-large {
       font-weight: 600;
       font-size: 24px;
-      margin: 27px 0px 0px 0px !important;
+      margin: 27px 0px 0px 60px !important;
     }
     .close {
       border-bottom: none !important;
@@ -56,7 +56,7 @@
       padding: 0px 0px 10px 0px !important;
     }
     &-large {
-      margin: -10px 55px !important;
+      margin: -10px 0px !important;
       padding: 0px 0px 10px 0px !important;
     }
   }

--- a/client/src/components/organisms/style/Modal.scss
+++ b/client/src/components/organisms/style/Modal.scss
@@ -42,7 +42,7 @@
   }
 }
 
-.modal {
+.logo-modal {
   align-items: center;
   text-align: center;
   .line {

--- a/client/src/components/organisms/style/Modal.scss
+++ b/client/src/components/organisms/style/Modal.scss
@@ -42,7 +42,7 @@
   }
 }
 
-.logo-modal {
+.modal {
   align-items: center;
   text-align: center;
   .line {
@@ -69,6 +69,12 @@
   &-xl {
     max-width: 1063px;
   }
+}
+
+.logo-modal {
+  align-items: center;
+  text-align: center;
+
   .button {
     color: #ffffff;
     background-color: $tpc-green;

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -35,9 +35,12 @@ $request-group-form-input-width: 373px;
     }
 
     .tag-input-form-item {
-      input {
+      .tag-input {
         width: $request-group-form-input-width;
-        height: 45px;
+        & input {
+          height: 45px;
+        }
+        
       }
       .form-item-top {
         width: $request-group-form-input-width;
@@ -46,7 +49,46 @@ $request-group-form-input-width: 373px;
         width: $request-group-form-input-width;
       }
       .form-item-error-icon {
-        margin-top: 8px;
+        margin-top: 5px;
+      }
+    }
+
+    .imagepicker-form-item {
+      .imagepicker-preview {
+        width: 348px;
+        height: 248px;
+        margin-left: 7px;
+      }
+
+      .form-item-top {
+        width: 348px;
+        margin-left: 7px;
+      }
+
+      .form-item-error-icon {
+        margin-right: -40px;
+      } 
+    }
+
+    .richtext-field-form-item {
+      & .richtext-field {
+        width: 484px;
+        height: 252px;
+      }
+
+      .form-item-top {
+        width: 484px;
+      }
+    }
+
+    &-footer {
+      & .button {
+        float: right;
+        background-color: $tpc-green;
+        &:hover {
+          background-color: $tpc-green-hover;
+          color: $white-text-color;
+        }
       }
     }
   }

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -55,8 +55,6 @@ $request-group-form-input-width: 373px;
 
     .imagepicker-form-item {
       .imagepicker-preview {
-        width: 348px;
-        height: 248px;
         margin-left: 7px;
       }
 

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -1,16 +1,24 @@
 .request-group-form {
   &-modal {
+    &-body {
+      padding: 0px 69px 40px 75px;
+    }
     &-content {
       display: flex;
       flex-direction: row;
+      justify-content: space-between;
     }
     &-panel {
       display: flex;
       flex-direction: column;
+      justify-content: space-between;
       // &#left {
       // }
       // &#right {
       // }
+      & .form-item {
+        margin-top: 31px;
+      }
     }
   }
 }

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -1,0 +1,16 @@
+.request-group-form {
+  &-modal {
+    &-content {
+      display: flex;
+      flex-direction: row;
+    }
+    &-panel {
+      display: flex;
+      flex-direction: column;
+      // &#left {
+      // }
+      // &#right {
+      // }
+    }
+  }
+}

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -40,7 +40,6 @@ $request-group-form-input-width: 373px;
         & input {
           height: 45px;
         }
-        
       }
       .form-item-top {
         width: $request-group-form-input-width;
@@ -65,7 +64,7 @@ $request-group-form-input-width: 373px;
 
       .form-item-error-icon {
         margin-right: -40px;
-      } 
+      }
     }
 
     .richtext-field-form-item {
@@ -88,6 +87,11 @@ $request-group-form-input-width: 373px;
           color: $white-text-color;
         }
       }
+    }
+
+    .alert-dialog {
+      margin-left: 18%;
+      margin-top: -100px;
     }
   }
 }

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -21,12 +21,14 @@ $request-group-form-input-width: 373px;
       }
     }
 
+    .text-field-input {
+      width: $request-group-form-input-width;
+      height: 45px;
+      
+      
+    }
+
     .text-field-form-item {
-      input {
-        width: $request-group-form-input-width;
-        height: 45px;
-        border: $dark-border;
-      }
       .form-item-top {
         width: $request-group-form-input-width;
       }
@@ -38,10 +40,7 @@ $request-group-form-input-width: 373px;
     .tag-input-form-item {
       .tag-input {
         width: $request-group-form-input-width;
-        & input {
-          height: 45px;
-          border: $dark-border;
-        }
+        
       }
       .form-item-top {
         width: $request-group-form-input-width;
@@ -83,6 +82,8 @@ $request-group-form-input-width: 373px;
     &-footer {
       & .button {
         float: right;
+        padding: 12px 33px;
+
         background-color: $tpc-green;
         &:hover {
           background-color: $tpc-green-hover;

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -1,7 +1,10 @@
+$request-group-form-input-width: 373px;
+
 .request-group-form {
   &-modal {
     &-body {
       padding: 0px 69px 40px 75px;
+      border-radius: unset;
     }
     &-content {
       display: flex;
@@ -12,12 +15,38 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      // &#left {
-      // }
-      // &#right {
-      // }
+
       & .form-item {
         margin-top: 31px;
+      }
+    }
+
+    .text-field-form-item {
+      input {
+        width: $request-group-form-input-width;
+        height: 45px;
+      }
+      .form-item-top {
+        width: $request-group-form-input-width;
+      }
+      .form-item-error-icon {
+        margin-top: 8px;
+      }
+    }
+
+    .tag-input-form-item {
+      input {
+        width: $request-group-form-input-width;
+        height: 45px;
+      }
+      .form-item-top {
+        width: $request-group-form-input-width;
+      }
+      .action {
+        width: $request-group-form-input-width;
+      }
+      .form-item-error-icon {
+        margin-top: 8px;
       }
     }
   }

--- a/client/src/components/organisms/style/RequestGroupForm.scss
+++ b/client/src/components/organisms/style/RequestGroupForm.scss
@@ -25,6 +25,7 @@ $request-group-form-input-width: 373px;
       input {
         width: $request-group-form-input-width;
         height: 45px;
+        border: $dark-border;
       }
       .form-item-top {
         width: $request-group-form-input-width;
@@ -39,6 +40,7 @@ $request-group-form-input-width: 373px;
         width: $request-group-form-input-width;
         & input {
           height: 45px;
+          border: $dark-border;
         }
       }
       .form-item-top {

--- a/client/src/components/organisms/style/index.scss
+++ b/client/src/components/organisms/style/index.scss
@@ -6,3 +6,4 @@
 @import "Modal";
 @import "DonorRequestGroupBrowser";
 @import "AdminRequestGroupList";
+@import "RequestGroupForm";

--- a/client/src/data/actionTypes.ts
+++ b/client/src/data/actionTypes.ts
@@ -7,3 +7,4 @@ export const LOAD_REQUESTS = "load_requests";
 
 export const LOAD_REQUEST_GROUPS = "load_request_groups";
 export const SET_DISPLAY_REQUEST_GROUPS = "set_display_request_groups";
+export const UPSERT_REQUEST_GROUP = "upsert_request_group";

--- a/client/src/data/actions/requestGroupsActions.ts
+++ b/client/src/data/actions/requestGroupsActions.ts
@@ -1,5 +1,5 @@
 /* Imports from local files */
-import { LOAD_REQUEST_GROUPS, SET_DISPLAY_REQUEST_GROUPS } from "../actionTypes";
+import { LOAD_REQUEST_GROUPS, SET_DISPLAY_REQUEST_GROUPS, UPSERT_REQUEST_GROUP } from "../actionTypes";
 import RequestGroup from '../types/requestGroup'
 
 /**
@@ -10,16 +10,23 @@ import RequestGroup from '../types/requestGroup'
  */
 export interface RequestGroupsAction {
   type: string,
-  payload: Array<RequestGroup>,
-  
+  payload: {
+    requestGroups?: Array<RequestGroup>,
+    requestGroup?: RequestGroup
+  },
 }
 
 export const loadRequestGroups = (data: Array<RequestGroup>): RequestGroupsAction => ({
   type: LOAD_REQUEST_GROUPS,
-  payload: data,
+  payload: { requestGroups: data },
 });
 
 export const setDisplayRequestGroups = (data: Array<RequestGroup>): RequestGroupsAction => ({
   type: SET_DISPLAY_REQUEST_GROUPS,
-  payload: data,
+  payload: { requestGroups: data },
+});
+
+export const upsertRequestGroup = (data: RequestGroup): RequestGroupsAction => ({
+  type: UPSERT_REQUEST_GROUP,
+  payload: { requestGroup: data },
 });

--- a/client/src/data/reducers/requestGroupsReducer.ts
+++ b/client/src/data/reducers/requestGroupsReducer.ts
@@ -1,5 +1,5 @@
 /* Imports from local files */
-import { LOAD_REQUEST_GROUPS, SET_DISPLAY_REQUEST_GROUPS } from "../actionTypes";
+import { LOAD_REQUEST_GROUPS, SET_DISPLAY_REQUEST_GROUPS, UPSERT_REQUEST_GROUP } from "../actionTypes";
 import RequestGroup from '../types/requestGroup'
 import { RequestGroupsAction } from '../actions/'
 
@@ -23,12 +23,36 @@ export default (state = defaultState, action: RequestGroupsAction): RequestGroup
     case LOAD_REQUEST_GROUPS:
       return {
         ...state,
-        data: action.payload,
+        data: action.payload.requestGroups ? action.payload.requestGroups : [],
       };
     case SET_DISPLAY_REQUEST_GROUPS:
       return {
         ...state,
-        displayData: action.payload, 
+        displayData: action.payload.requestGroups ? action.payload.requestGroups : [],
+      };
+    case UPSERT_REQUEST_GROUP:
+      let dataCopy = state.data;
+      
+      if (action.payload.requestGroup) {
+        const targetRequestGroup: RequestGroup = action.payload.requestGroup;
+
+        let found = false;
+        dataCopy = dataCopy.map((requestGroup: RequestGroup) => {
+          if (requestGroup._id && requestGroup._id === targetRequestGroup._id) {
+            found = true;
+            return targetRequestGroup;
+          }
+          return requestGroup;
+        })
+
+        if (!found) {
+          dataCopy.push(targetRequestGroup)
+        }
+      }
+
+      return {
+        ...state,
+        data: dataCopy,
       };
     default:
       return state;

--- a/client/src/data/reducers/requestGroupsReducer.ts
+++ b/client/src/data/reducers/requestGroupsReducer.ts
@@ -18,6 +18,7 @@ const defaultState: RequestGroupsState = {
  * these replacements should be immutable.
  */
 export default (state = defaultState, action: RequestGroupsAction): RequestGroupsState => {
+  let dataCopy = state.data;
   switch (action.type) {
     // directly sets the global data to the payload as specified in the action
     case LOAD_REQUEST_GROUPS:
@@ -31,7 +32,6 @@ export default (state = defaultState, action: RequestGroupsAction): RequestGroup
         displayData: action.payload.requestGroups ? action.payload.requestGroups : [],
       };
     case UPSERT_REQUEST_GROUP:
-      let dataCopy = state.data;
       
       if (action.payload.requestGroup) {
         const targetRequestGroup: RequestGroup = action.payload.requestGroup;

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -198,7 +198,6 @@ $tag-background: #ededed;
 /* Modal Config */
 $input-icon-color: #adadad;
 $tpc-green: #004d57;
-$input-border: #e9e9e9;
 $disabled-text: #adadad;
 $input-error: $error-color;
 $faint-input-error: #e7b0b5;
@@ -215,7 +214,7 @@ $dark-border: 1px solid $dark-border-color;
 
 /* ScrollWindow Config */
 $scroll-bar-color: #c4c4c4;
-$scroll-window-border: 1px solid $window-border-color;
+$window-border: 1px solid $window-border-color;
 
 /* AuthModal Config */
 $auth-modal-content-width: 385px;

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -211,6 +211,7 @@ $tpc-green-hover: #00363e;
 /* TextField Config */
 $soft-black: #333333;
 $textfield-input-border: #797979;
+$dark-border: 1px solid $dark-border-color;
 
 /* ScrollWindow Config */
 $scroll-bar-color: #c4c4c4;

--- a/client/src/style/_config.scss
+++ b/client/src/style/_config.scss
@@ -19,7 +19,7 @@ $alt-faded-text-color: #a3a3a3;
 $grey-text-color: #333333;
 $faded-modal-text-color: #7d7d7d;
 $normal-text-color: black;
-$error-text-color: #e7b0b5;
+$error-faded-color: #e7b0b5;
 $white-text-color: white;
 $section-header-text-color: #bbbbbb;
 $tooltip-background-color: #efefef;
@@ -44,7 +44,7 @@ $window-border-color: #d7d7d7;
 
 @mixin error-text() {
   @include text;
-  color: $error-text-color;
+  color: $error-faded-color;
 }
   
 @mixin small-text(){


### PR DESCRIPTION
Live Demo: https://bp-pregnancy-centre.web.app/request-group-form
List of all request groups is printed in the console.

TODO: send graphql mutation requests (to be included in another PR)

Changes:
+ Add redux to upsert a RequestGroup to store.requestGroups.data
+ create/edit Request Group modal
+ many  styling changes to atoms/molecules used in Request Group Form
 

Please look at the **modified components that are shared with other pages**:
+ Button.tsx
+ TextField.tsx
+ LogoModal.tsx
+ Modal.tsx
+ Modal.scss

    