### PR TITLE
Fixed bug - requestGroupsList wasn't displaying all requestGroups (empty fourth page)

### DIFF
--- a/client/src/components/organisms/RequestGroupList.tsx
+++ b/client/src/components/organisms/RequestGroupList.tsx
@@ -23,7 +23,7 @@ const RequestGroupList: FunctionComponent<Props> = (props: Props) => {
   return <div className="request-group-list">
     <div className="request-group-list-scroll-window">
       <RequestGroupScrollWindow
-        requestGroups={props.requestGroups.slice((currentPage - 1) * numGroupsPerPage, Math.min(currentPage * numGroupsPerPage, props.requestGroups.length - 1))}
+        requestGroups={props.requestGroups.slice((currentPage - 1) * numGroupsPerPage, Math.min(currentPage * numGroupsPerPage, props.requestGroups.length))}
         selectedRequestGroup={props.selectedRequestGroup}
         onRequestGroupChange={props.onRequestGroupChange} />
     </div>


### PR DESCRIPTION
Bug fixed where only N-1 of N requestGroups appeared in requestGroupsList.

Issue was because arrays are 0-indexed and the end of a slice is one index further than the resulting sliced array.