### PR TITLE
styling for DonorHomepage PageNavigation

### DIFF
--- a/client/src/components/atoms/PageNavigation.tsx
+++ b/client/src/components/atoms/PageNavigation.tsx
@@ -30,7 +30,7 @@ const PageNavigation: FunctionComponent<Props> = (props: Props) => {
         Array.from(Array(props.pages).keys()).map((i: number) =>
           <Pagination.Item
             key={i}
-            className={currentPage === i + 1 ? "active" : "inactive"}
+            className={"page-number " + (currentPage === i + 1 ? "active" : "inactive")}
             onClick={onPageSelect}
           >
             {i + 1}

--- a/client/src/components/atoms/style/PageNavigation.scss
+++ b/client/src/components/atoms/style/PageNavigation.scss
@@ -21,8 +21,15 @@
   width: 35px;
   height: 35px;
 
-  margin-left: 7px;
-  margin-right: 7px;
+  margin-left: 6px;
+  margin-right: 6px;
+
+  .page-number {
+    @include heavy-text;
+    font-size: 15px;
+    line-height: 18px;
+    letter-spacing: 0.05em;
+  }
 
   &:focus {
     border-color: none;
@@ -43,15 +50,15 @@
 }
 
 .page-arrow {
-  width: 41px;
+  width: 48px;
   font-size: 30px;
 
-  & .page-link {
+  .page-link {
     color: $button-background;
     @include transparent;
   }
 
-  &.prev-arrow {
+  .prev-arrow {
     margin: 0;
   }
 
@@ -59,7 +66,7 @@
     // &.next-arrow {
     //   padding-left: 7px;
     // }
-    &.page-item {
+    .page-link {
       color: $button-disabled-background;
       align-self: center;
       @include transparent;


### PR DESCRIPTION
Styling now more on inline with Figma:
![image](https://user-images.githubusercontent.com/32274856/114908687-52ae6100-9dea-11eb-940a-fe3c0318e8fb.png)

Included is the desired style change on arrow colour.

For whoever made this PR originally, &<selector> selector applies to parent selector of the SCSS block.