### PR TITLE
fixed cursor for create new request group

### DIFF
--- a/client/src/components/molecules/style/RequestGroupTable.scss
+++ b/client/src/components/molecules/style/RequestGroupTable.scss
@@ -118,5 +118,6 @@
     .create-group-link {
         @include bold-text;
         color: $tpc-green;
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
Just made it so that when there are no request groups, the prompt to create a request group has a pointer cursor as it can be clicked.