### PR TITLE
When a create/edit modal is submitted, now reloads

### DIFF
--- a/client/src/components/examples/CreateRequestFormContainer.tsx
+++ b/client/src/components/examples/CreateRequestFormContainer.tsx
@@ -3,11 +3,11 @@ import React, { FunctionComponent, useState } from "react";
 import RequestForm from "../organisms/RequestForm";
 
 
-const CreateRequestGroupFormContainer: FunctionComponent<Record<string, never>> = () => {
+const CreateRequestFormContainer: FunctionComponent<Record<string, never>> = () => {
   const [show, setShow] = useState(true);
 
-  return (<>{show && <RequestForm handleClose={() => setShow(false)} operation="create" />}</>)
+  return (<>{show && <RequestForm onSubmitComplete={() => { window.location.reload() }} handleClose={() => setShow(false)} operation="create" />}</>)
 };
 
-export default CreateRequestGroupFormContainer
+export default CreateRequestFormContainer
 

--- a/client/src/components/examples/CreateRequestGroupFormContainer.tsx
+++ b/client/src/components/examples/CreateRequestGroupFormContainer.tsx
@@ -36,7 +36,7 @@ const CreateRequestGroupFormContainer: FunctionComponent<Props> = (props: Props)
     },
   });
 
-  return (<>{show && <RequestGroupForm onSubmitComplete={()=> {}} handleClose={() => setShow(false)} operation="create" />}</>)
+  return (<>{show && <RequestGroupForm onSubmitComplete={() => { window.location.reload() }} handleClose={() => setShow(false)} operation="create" />}</>)
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {

--- a/client/src/components/examples/EditRequestFormContainer.tsx
+++ b/client/src/components/examples/EditRequestFormContainer.tsx
@@ -6,7 +6,7 @@ import RequestForm from "../organisms/RequestForm";
 const EditRequestGroupFormContainer: FunctionComponent<Record<string, never>> = () => {
   const [show, setShow] = useState(true);
 
-  return (<>{show && <RequestForm handleClose={() => setShow(false)} operation="edit" requestId="6077592acca67d9812f94df5" />}</>)
+  return (<>{show && <RequestForm onSubmitComplete={() => { window.location.reload() }} handleClose={() => setShow(false)} operation="edit" requestId="6077592acca67d9812f94df5" />}</>)
 };
 
 export default EditRequestGroupFormContainer

--- a/client/src/components/examples/EditRequestGroupFormContainer.tsx
+++ b/client/src/components/examples/EditRequestGroupFormContainer.tsx
@@ -36,7 +36,7 @@ const EditRequestGroupFormContainer: FunctionComponent<Props> = (props: Props) =
     },
   });
 
-  return (<>{show && <RequestGroupForm onSubmitComplete={()=>{}} handleClose={() => setShow(false)} operation="edit" requestGroupId="607663bb2cbfaf98de609fa3" />}</>)
+  return (<>{show && <RequestGroupForm onSubmitComplete={() => { window.location.reload() }} handleClose={() => setShow(false)} operation="edit" requestGroupId="607663bb2cbfaf98de609fa3" />}</>)
 };
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => {

--- a/client/src/components/molecules/RequestsTable.tsx
+++ b/client/src/components/molecules/RequestsTable.tsx
@@ -111,7 +111,7 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
 
     return (
         <div className="request-list">
-            { requestSelectedForEditing && <RequestForm handleClose={() => setRequestSelectedForEditing("")} operation="edit" requestId={requestSelectedForEditing} /> }
+            { requestSelectedForEditing && <RequestForm onSubmitComplete={() => { window.location.reload() }} handleClose={() => setRequestSelectedForEditing("")} operation="edit" requestId={requestSelectedForEditing} /> }
             { requests.length === 0 ? <p className="request-table-empty-message">There are currently no requests in this type</p> : 
             <Table responsive className="request-table">
                 <thead>

--- a/client/src/components/organisms/AdminRequestGroupList.tsx
+++ b/client/src/components/organisms/AdminRequestGroupList.tsx
@@ -90,8 +90,8 @@ const AdminRequestGroupList: FunctionComponent<Props> = (props: React.PropsWithC
     return (
 
         <div className="admin-request-group-list">
-            { showCreateRequestModal && <RequestForm handleClose={() => setShowCreateRequestModal(false)} operation="create" /> }
-            { showCreateRequestGroupModal && <RequestGroupForm onSubmitComplete={() => { }} handleClose={() => setShowCreateRequestGroupModal(false)} operation="create" />}
+            { showCreateRequestModal && <RequestForm onSubmitComplete={() => {}} handleClose={() => setShowCreateRequestModal(false)} operation="create" /> }
+            { showCreateRequestGroupModal && <RequestGroupForm onSubmitComplete={() => { window.location.reload() }} handleClose={() => setShowCreateRequestGroupModal(false)} operation="create" />}
             <div className="row">
                 <span className="title">Request Groups</span>
                 <span className="action-group">

--- a/client/src/components/organisms/RequestForm.tsx
+++ b/client/src/components/organisms/RequestForm.tsx
@@ -15,6 +15,7 @@ import { TextField } from '../atoms/TextField'
 
 interface Props {
   handleClose: () => void
+  onSubmitComplete: () => void
   requestId?: string
   operation: "create" | "edit"
 }
@@ -73,8 +74,14 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     }
   }`
 
-  const [createRequest] = useMutation(createRequestMutation);
-  const [updateRequest] = useMutation(updateRequestMutation);
+  const [createRequest] = useMutation(createRequestMutation, {
+    onCompleted: () => { props.onSubmitComplete() },
+    onError: (error) => { console.log(error) }
+  });
+  const [updateRequest] = useMutation(updateRequestMutation, {
+    onCompleted: () => { props.onSubmitComplete() },
+    onError: (error) => { console.log(error) }
+  });
 
   const fetchRequestGroups = gql`
   query FetchRequestGroups {
@@ -304,7 +311,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
               clientName
             }
           })
-            .catch((err) => { console.log(err) })
         }
       }
       else {
@@ -318,7 +324,6 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
               clientName,
             }
           })
-            .catch((err) => { console.log(err) })
         }
       }
       props.handleClose()

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -99,8 +99,14 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     }
   }`
 
-  const [createRequestGroup] = useMutation(createRequestGroupMutation);
-  const [updateRequestGroup] = useMutation(updateRequestGroupMutation);
+  const [createRequestGroup] = useMutation(createRequestGroupMutation, {
+    onCompleted: () => { props.onSubmitComplete() },
+    onError: (error) => { console.log(error) }
+  });
+  const [updateRequestGroup] = useMutation(updateRequestGroupMutation, {
+    onCompleted: () => { props.onSubmitComplete() },
+    onError: (error) => { console.log(error) }
+  });
 
 
   const requestGroupQuery = gql`
@@ -288,15 +294,10 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
       if (props.operation === "create") {
 
         createRequestGroup({ variables: { name, description, image, requestTypeNames } })
-          .catch((err) => { console.log(err) })
       }
       else {
 
         updateRequestGroup({ variables: { id: props.requestGroupId, name, description, image, requestTypeNames } })
-          .then(()=>{
-            props.onSubmitComplete();
-          })
-          .catch((err) => { console.log(err) })
       }
       props.handleClose()
     }


### PR DESCRIPTION
Create/edit modals now all uniformly take an onSubmitComplete prop that is called when a mutation is completed.

Note that useMutation takes options and should not be used as a normal Promise (the Promise "completes" on sending the query, not on receiving confirmation it completed @meganniu 