### PR TITLE
Create request modal nogrouptext

### DIFF
--- a/client/src/components/atoms/SearchableDropdown.tsx
+++ b/client/src/components/atoms/SearchableDropdown.tsx
@@ -97,7 +97,7 @@ const SearchableDropdown: FunctionComponent<Props> = (props: Props) => {
       </div>
       {dropdownExpanded && (
         <span ref={dropdownReference}>
-          {noItems ? (
+          {noItems || props.dropdownItems?.length === 0 ? (
             props.noItemsAction
           ) : (
               <div>

--- a/client/src/components/organisms/RequestForm.tsx
+++ b/client/src/components/organisms/RequestForm.tsx
@@ -375,7 +375,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => { onRequestGroupInputChange(e.target.value) }}
                   onSelect={onRequestGroupChange}
                   noItemsAction={(<div className="no-items-found">
-                    <span className="not-exist-msg">{requestGroupsMap?.size === 0 ? "There are no request groups" : "This group does not exist"}</span>
+                    <span className="not-exist-msg">{!requestGroupsMap || requestGroupsMap.size === 0 ? "There are no request groups" : "This group does not exist"}</span>
                     {/* <span className="create-group">
                       <a>
                         <span>Create a new group</span>

--- a/client/src/components/organisms/RequestForm.tsx
+++ b/client/src/components/organisms/RequestForm.tsx
@@ -101,7 +101,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
           return entries
         },
           [] as Array<[string, RequestGroup]>))
-      setRequestGroupsMap(map)
+      //setRequestGroupsMap(map)
 
       // For the edit request form, check that we're not waiting for the request to load before setting loading = false
       if (!(props.operation === 'edit' && !initialRequest)) {
@@ -375,7 +375,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => { onRequestGroupInputChange(e.target.value) }}
                   onSelect={onRequestGroupChange}
                   noItemsAction={(<div className="no-items-found">
-                    <span className="not-exist-msg">This group does not exist</span>
+                    <span className="not-exist-msg">{requestGroupsMap?.size === 0 ? "There are no request groups" : "This group does not exist"}</span>
                     {/* <span className="create-group">
                       <a>
                         <span>Create a new group</span>

--- a/client/src/components/organisms/RequestForm.tsx
+++ b/client/src/components/organisms/RequestForm.tsx
@@ -101,7 +101,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
           return entries
         },
           [] as Array<[string, RequestGroup]>))
-      //setRequestGroupsMap(map)
+      setRequestGroupsMap(map)
 
       // For the edit request form, check that we're not waiting for the request to load before setting loading = false
       if (!(props.operation === 'edit' && !initialRequest)) {


### PR DESCRIPTION
Now shows "There are no request groups" in the SearchableDropdown if that is in fact the case.

![image](https://user-images.githubusercontent.com/32274856/114932828-f35e4a00-9e05-11eb-8ce4-cf2b2670ab82.png)
