### PR TITLE
fixed 3-dot dropdown padding

### DIFF
--- a/client/src/components/organisms/style/AdminRequestGroupBrowser.scss
+++ b/client/src/components/organisms/style/AdminRequestGroupBrowser.scss
@@ -27,9 +27,10 @@
         border-radius: 4px;
         box-shadow: 0 4px 3px $admin-request-group-browser-dropdown-shadow-color; 
         border: none;
+        padding: 0;
 
         &-item {
-            padding-top: 15px;
+            padding: 14px 20px;
         }
     }
 


### PR DESCRIPTION
Padding now as in Figma

Normal:
![image](https://user-images.githubusercontent.com/32274856/114934334-c6ab3200-9e07-11eb-872e-7b32ab02cfb7.png)


Hover:
![image](https://user-images.githubusercontent.com/32274856/114934304-bc893380-9e07-11eb-8535-d95da274d70c.png)
