### PR TITLE
Initial typing in RequestGroup description no longer has error

### DIFF
--- a/client/src/components/atoms/RichTextField.tsx
+++ b/client/src/components/atoms/RichTextField.tsx
@@ -53,7 +53,6 @@ const RichTextField: FunctionComponent<Props> = (props: Props) => {
         // current component state
         let isEmpty = empty
         let hasChangeMade = changeMade
-        console.log("Empty: " + isEmpty + " | ChangeMade: " + hasChangeMade)
 
         // if user is typing content, so this is active
         if (!active) {

--- a/client/src/components/organisms/AdminRequestGroupList.tsx
+++ b/client/src/components/organisms/AdminRequestGroupList.tsx
@@ -67,8 +67,6 @@ const AdminRequestGroupList: FunctionComponent<Props> = (props: React.PropsWithC
     useQuery(query, {
         onCompleted: (data: { requestGroups: Array<RequestGroup> }) => {
             // sort fetched request groups alphabetically and filter out deleted request groups
-            console.log("got request groups!");
-            console.log(data.requestGroups);
             const displayRequestGroups = sortRequestGroupsAlphabetically(data.requestGroups.map(requestGroup => ({ ...requestGroup }))).filter(requestGroup => !requestGroup.deleted);
             props.loadRequestGroups(displayRequestGroups);
             props.setDisplayRequestGroups(displayRequestGroups);

--- a/client/src/components/organisms/RequestGroupForm.tsx
+++ b/client/src/components/organisms/RequestGroupForm.tsx
@@ -251,7 +251,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
   const onDescriptionChange = (newDescription: string) => {
     setChangeMade(true);
     setDescription(newDescription);
-    updateDescriptionError(description);
+    updateDescriptionError(newDescription);
   };
 
   const onDecriptionEmpty = () => {


### PR DESCRIPTION
Now, when someone first clicks on RequestGroup description in a request group form, no error is shown. Fixed some general errors and mistakes in related code

Removed some console.log someone left