### PR TITLE
refactored display of body on dropdown

### DIFF
--- a/client/src/components/atoms/Dropdown.tsx
+++ b/client/src/components/atoms/Dropdown.tsx
@@ -26,9 +26,9 @@ const Dropdown:  FunctionComponent<Props> = (props: Props) => {
                     {props.header}
                 </div>
             </div>
-            {open && (
-                props.body
-            )}
+            <div className={"dropdown-body-"+ (open ? "open" : "closed")}>   
+                {props.body}    
+            </div>
             </div>
       </div>
   );

--- a/client/src/components/atoms/style/Dropdown.scss
+++ b/client/src/components/atoms/style/Dropdown.scss
@@ -62,6 +62,15 @@
          font-size: 16px;
        }
      }
+
+      .dropdown-body-open {
+        visibility: visible;
+      }
+
+      .dropdown-body-closed {
+        display: none;
+        visibility: hidden;
+      }
    
      .dropdown-list {
        box-shadow: 0 .125rem .25rem rgba(0,0,0,.075) !important;


### PR DESCRIPTION
This PR addresses ticket: https://www.notion.so/uwblueprintexecs/34a44be943164278bfbf43de35e4ef7b?v=925be7afd3e246a48f535ff61fc1e464&p=db2cbc79cc514ba1a02be85e6e4d2e60

Changes:
- refactored Dropdown component so display of body is handled through css instead of React

