### PR TITLE
Added delete propagation for RequestGroup and RequestType

### DIFF
--- a/server/api/resolvers/requestTypeResolvers.ts
+++ b/server/api/resolvers/requestTypeResolvers.ts
@@ -125,9 +125,25 @@ const requestTypeMutationResolvers = {
     },
     deleteRequestType: async (_, { _id }, { authenticateUser }): Promise<RequestTypeInterface> => {
         return authenticateUser().then(async () => {
-            const requestType = await RequestType.findById(_id);
-            requestType.deletedAt = new Date();
-            return requestType.save();
+            return sessionHandler(async (session) => {
+                const requestType = await RequestType.findById(_id).session(session);
+
+                if (requestType.deletedAt != null) return requestType.save({ session: session });
+
+                requestType.deletedAt = new Date();
+
+                for (var i = 0; i < requestType.requests.length; i++) {
+                    const request = await Request.findById(requestType.requests[i]._id).session(session);
+
+                    if (request.deletedAt != null) continue;
+
+                    request.deletedAt = new Date();
+                    requestType.requests[i].deletedAt = request.deletedAt;
+                    await request.save({ session: session });
+                }
+
+                return requestType.save({ session: session });
+            });
         });
     },
     changeRequestGroupForRequestType: async (


### PR DESCRIPTION
Added delete propagation for RequestGroup and RequestType such that deleting RequestGroup deletes all contained RequestTypes and deleting RequestType deletes all contained Requests.