### PR TITLE
Bug fixes - deleted requestGroups and requestTypes appearing

### DIFF
--- a/client/src/components/organisms/AdminRequestGroupList.tsx
+++ b/client/src/components/organisms/AdminRequestGroupList.tsx
@@ -21,7 +21,7 @@ const AdminRequestGroupList: FunctionComponent = () => {
 
     const getPageQuery = gql`
         query GetRequestGroupsPage($skip: Int!, $limit: Int!, $name: String) {
-            requestGroupsPage(skip: $skip, limit: $limit, name: $name) {
+            requestGroupsPage(skip: $skip, limit: $limit, name: $name, open: true) {
                 _id
                 updatedAt
                 name

--- a/client/src/components/organisms/RequestGroupDonorView.tsx
+++ b/client/src/components/organisms/RequestGroupDonorView.tsx
@@ -30,6 +30,7 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
                     _id
                     name
                     countOpenRequests
+                    deletedAt
                 }
             }
         }
@@ -68,7 +69,7 @@ const RequestGroupDonorView: FunctionComponent<Props> = (props: Props) => {
                             </div>
                         </div>
                         <RequestTypeList
-                            requestTypes={requestGroupData.requestTypes ? requestGroupData.requestTypes : []}
+                            requestTypes={requestGroupData.requestTypes ? requestGroupData.requestTypes.filter(requestType => requestType.deletedAt == null) : []}
                         />
                     </div>
                     <div className="section" id="right">

--- a/client/src/components/organisms/RequestGroupList.tsx
+++ b/client/src/components/organisms/RequestGroupList.tsx
@@ -23,7 +23,7 @@ const RequestGroupList: FunctionComponent<Props> = (props: Props) => {
 
     const getPageQuery = gql`
         query GetRequestGroupsPage($skip: Int!, $limit: Int!) {
-            requestGroupsPage(skip: $skip, limit: $limit) {
+            requestGroupsPage(skip: $skip, limit: $limit, open: true) {
                 _id
                 name
                 image

--- a/server/api/resolvers/requestGroupResolvers.ts
+++ b/server/api/resolvers/requestGroupResolvers.ts
@@ -46,16 +46,15 @@ const requestGroupQueryResolvers = {
     requestGroups: async (_, __, ___): Promise<Array<RequestGroupInterface>> => {
         return RequestGroup.find().exec();
     },
-    requestGroupsPage: async (_, { skip, limit, name }, __): Promise<Array<RequestGroupInterface>> => {
+    requestGroupsPage: async (_, { skip, limit, name, open }, __): Promise<Array<RequestGroupInterface>> => {
+        const filter: {[key: string]: any} = {};
         if (name) {
-            return RequestGroup.find({ name: { $regex: "^" + name + ".*", $options: "i" } })
-                .sort({ name: "ascending", _id: "ascending" })
-                .skip(skip)
-                .limit(limit)
-                .exec();
-        } else {
-            return RequestGroup.find().sort({ name: "ascending", _id: "ascending" }).skip(skip).limit(limit).exec();
+            filter.name = { $regex: "^" + name + ".*", $options: "i" };
         }
+        if (open) {
+            filter.deletedAt = { $eq: null };
+        }
+        return RequestGroup.find(filter).sort({ name: "ascending", _id: "ascending" }).skip(skip).limit(limit).exec();
     },
     countRequestGroups: async (_, { open }, ___): Promise<number> => {
         if (open) {

--- a/server/api/resolvers/requestResolvers.ts
+++ b/server/api/resolvers/requestResolvers.ts
@@ -41,7 +41,12 @@ const requestQueryResolvers = {
     requests: async (_, __, ___): Promise<Array<RequestInterface>> => {
         return Request.find().exec();
     },
-    requestsPage: async (_, { skip, limit }, __): Promise<Array<RequestInterface>> => {
+    requestsPage: async (_, { skip, limit, open }, __): Promise<Array<RequestInterface>> => {
+        const filter: {[key: string]: any} = {};
+        if (open) {
+            filter.deletedAt = { $eq: null };
+            filter.fulfilledAt = { $eq: null };
+        }
         return Request.find().sort({ name: "ascending", _id: "ascending" }).skip(skip).limit(limit).exec();
     },
     countRequests: async (_, { open }, ___): Promise<number> => {

--- a/server/api/resolvers/requestTypeResolvers.ts
+++ b/server/api/resolvers/requestTypeResolvers.ts
@@ -75,8 +75,12 @@ const requestTypeQueryResolvers = {
     requestTypes: async (_, __, ___): Promise<Array<RequestTypeInterface>> => {
         return RequestType.find().exec();
     },
-    requestTypesPage: async (_, { skip, limit }, __): Promise<Array<RequestTypeInterface>> => {
-        return RequestType.find().sort({ name: "ascending", _id: "ascending" }).skip(skip).limit(limit).exec();
+    requestTypesPage: async (_, { skip, limit, open }, __): Promise<Array<RequestTypeInterface>> => {
+        const filter: {[key: string]: any} = {};
+        if (open) {
+            filter.deletedAt = { $eq: null };
+        }
+        return RequestType.find(filter).sort({ name: "ascending", _id: "ascending" }).skip(skip).limit(limit).exec();
     },
     countRequestTypes: async (_, { open }, ___): Promise<number> => {
         if (open) {

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -199,21 +199,21 @@ const typeDefs = gql`
     type Query {
         request(_id: ID): Request
         requests: [Request]
-        requestsPage(skip: Int, limit: Int): [Request]
+        requestsPage(skip: Int, limit: Int, open: Boolean): [Request]
         countRequests(open: Boolean): Int
         # --- Left as a proof of concept: ---
         # requestsFilter(filter: FilterRequestInput, options: FilterOptions): [Request]
 
         requestType(_id: ID): RequestType
         requestTypes: [RequestType]
-        requestTypesPage(skip: Int, limit: Int): [RequestType]
+        requestTypesPage(skip: Int, limit: Int, open: Boolean): [RequestType]
         countRequestTypes(open: Boolean): Int
         # --- Left as a proof of concept: ---
         # requestTypesFilter(filter: FilterRequestTypeInput, options: FilterOptions): [RequestType]
 
         requestGroup(_id: ID): RequestGroup
         requestGroups: [RequestGroup]
-        requestGroupsPage(skip: Int, limit: Int, name: String): [RequestGroup]
+        requestGroupsPage(skip: Int, limit: Int, name: String, open: Boolean): [RequestGroup]
         countRequestGroups(open: Boolean): Int
         # --- Left as a proof of concept: ---
         # requestGroupsFilter(filter: FilterRequestGroupInput, options: FilterOptions): [RequestGroup]


### PR DESCRIPTION
Fixed two bugs:

- on DonorHomepage and AdminHomepage, deleted requestGroups no longer appear
- on DonorHomepage, deleted requestTypes no longer appear