### PR TITLE
RequestGroup deletion confirmation modal

### DIFF
--- a/client/src/components/molecules/RequestTypeDropdown.tsx
+++ b/client/src/components/molecules/RequestTypeDropdown.tsx
@@ -70,7 +70,7 @@ const RequestTypeDropdown: FunctionComponent<Props> = (props: Props) => {
     };
 
     useEffect(() => {
-        setNumRequests(props.requests!.reduce((total, request) => (request.deleted === false ? total + 1 : total), 0));
+        setNumRequests(props.requests!.reduce((total, request) => (request.deletedAt == null ? total + 1 : total), 0));
     }, []);
 
     const handleChangeNumRequests = (num: number) => {

--- a/client/src/components/molecules/RequestsTable.tsx
+++ b/client/src/components/molecules/RequestsTable.tsx
@@ -42,7 +42,7 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
     useEffect(() => {
         const nonFulfilledRequests = requests.filter((request) => {
             if (request !== undefined) {
-                if (request.fulfilled == null) {
+                if (request.fulfilledAt == null) {
                     return request;
                 }
             }

--- a/client/src/components/molecules/RequestsTable.tsx
+++ b/client/src/components/molecules/RequestsTable.tsx
@@ -13,6 +13,7 @@ interface Props {
 }
 
 const RequestsTable: FunctionComponent<Props> = (props: Props) => {
+    const [requests, setRequests] = useState(props.requests.filter((request) => request.deletedAt == null));
     const [requestSelectedForEditing, setRequestSelectedForEditing] = useState("");
 
     const headingList = ["Fulfilled", "Client Name", "Quantity", "Date Requested", ""];
@@ -38,19 +39,17 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
         }
     `;
 
-    const [requests, setRequests] = useState(props.requests.filter((request) => request.deleted === false));
-
     useEffect(() => {
         const nonFulfilledRequests = requests.filter((request) => {
             if (request !== undefined) {
-                if (request.fulfilled === false) {
+                if (request.fulfilled == null) {
                     return request;
                 }
             }
         });
         const fulfilledRequests = requests.filter((request) => {
             if (request !== undefined) {
-                if (request.fulfilled === true) {
+                if (request.fulfilledAt != null) {
                     return request;
                 }
             }
@@ -66,7 +65,7 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
 
         const sortedRequests: Request[] = nonFulfilledRequests!.concat(fulfilledRequests!) as Request[];
         setRequests(sortedRequests);
-    }, []);
+    }, [props.requests]);
 
     const [mutateDeleteRequest] = useMutation(deleteRequest);
     const [mutateFulfillRequest] = useMutation(fulfillRequest, {
@@ -126,35 +125,35 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
                     </thead>
                     <tbody>
                         {requests.map((request, index) =>
-                            request.deleted === false ? (
+                            request.deletedAt == null ? (
                                 <tr key={request._id}>
                                     <td>
                                         <div>
                                             <Form.Check
                                                 type="checkbox"
                                                 onClick={() => onFulfilledRequest(request)}
-                                                defaultChecked={request.fulfilled}
+                                                defaultChecked={request.fulfilledAt != null}
                                             />
                                         </div>
                                     </td>
                                     {request.clientName !== null ? (
-                                        <td style={requests[index].fulfilled ? { opacity: 0.2 } : undefined}>
+                                        <td style={request.fulfilledAt ? { opacity: 0.2 } : undefined}>
                                             <div className="row-text-style">{request.clientName}</div>
                                         </td>
                                     ) : (
                                         <td>N/A</td>
                                     )}
-                                    <td style={requests[index].fulfilled ? { opacity: 0.2 } : undefined}>
+                                    <td style={request.fulfilledAt ? { opacity: 0.2 } : undefined}>
                                         {request.quantity}
                                     </td>
-                                    <td style={requests[index].fulfilled ? { opacity: 0.2 } : undefined}>
+                                    <td style={request.fulfilledAt ? { opacity: 0.2 } : undefined}>
                                         {moment(request.createdAt, "x").format("MMMM DD, YYYY")}
                                     </td>
                                     <td>
                                         <div className="btn-cont">
                                             <td>
                                                 <a
-                                                    className="request-table edit"
+                                                    className="edit"
                                                     onClick={() => {
                                                         if (request._id) {
                                                             setRequestSelectedForEditing(request._id);
@@ -166,7 +165,7 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
                                             </td>
                                             <td>
                                                 <a
-                                                    className="request-table delete"
+                                                    className="delete"
                                                     onClick={() => onDeleteRequest(index)}
                                                 >
                                                     <i className="bi bi-trash"></i>
@@ -180,8 +179,6 @@ const RequestsTable: FunctionComponent<Props> = (props: Props) => {
                     </tbody>
                 </Table>
             )}
-
-            {/* TODO: Add Edit and Delete Request Modals here*/}
         </div>
     );
 };

--- a/client/src/components/molecules/style/RequestsTable.scss
+++ b/client/src/components/molecules/style/RequestsTable.scss
@@ -8,8 +8,12 @@
     width: 1200px;
     margin-left: auto;
     margin-right: auto;
+    .form-check-input {
+        cursor: pointer;
+    }
     .edit {
         color: #333333;
+        cursor: pointer;
     }
     .delete {
         color: #333333;

--- a/client/src/components/organisms/AdminRequestGroupBrowser.tsx
+++ b/client/src/components/organisms/AdminRequestGroupBrowser.tsx
@@ -27,23 +27,18 @@ const AdminRequestGroupBrowser: FunctionComponent = () => {
             requestGroup(_id: $id) {
                 _id
                 name
-                description
-                updatedAt
                 deleted
                 countOpenRequests
                 requestTypes {
                     _id
                     name
-                    updatedAt
                     deleted
                     requests {
                         _id
-                        quantity
-                        updatedAt
                         createdAt
+                        deletedAt
                         fulfilledAt
-                        deleted
-                        fulfilled
+                        quantity
                         clientName
                     }
                 }
@@ -73,14 +68,14 @@ const AdminRequestGroupBrowser: FunctionComponent = () => {
         }
     }, [requestGroup]);
 
-    const deleteQuery = gql`
+    const deleteRequestGroupQuery = gql`
         mutation deleteRequestGroup($id: ID) {
             deleteRequestGroup(_id: $id) {
                 _id
             }
         }
     `;
-    const [mutateDeleteRequestGroup] = useMutation(deleteQuery);
+    const [mutateDeleteRequestGroup] = useMutation(deleteRequestGroupQuery);
 
     const deleteRequestGroup = async () => {
         await mutateDeleteRequestGroup({ variables: { id: requestGroup?._id } });

--- a/client/src/components/organisms/DeleteRequestGroupDialog.tsx
+++ b/client/src/components/organisms/DeleteRequestGroupDialog.tsx
@@ -23,7 +23,7 @@ const DeleteRequestTypeDialog: FunctionComponent<Props> = (props: Props) => {
         >
             <div>
                 <p>
-                    Are you sure you want to delete the group <b>&#34;{props.requestGroupName ?? "this"}&#34;</b>? This will delete the{" "}
+                    Are you sure you want to delete the group<b>&#34;{props.requestGroupName ? " " + props.requestGroupName : ""}&#34;</b>? This will delete the{" "}
                     <b>{props.numRequests}</b> requests in this group and cannot be undone.
                 </p>
             </div>

--- a/client/src/components/organisms/DeleteRequestGroupDialog.tsx
+++ b/client/src/components/organisms/DeleteRequestGroupDialog.tsx
@@ -13,7 +13,7 @@ interface Props {
 const DeleteRequestTypeDialog: FunctionComponent<Props> = (props: Props) => {
     return (
         <FormModal
-            className="delete-request-type-form"
+            className="delete-request-group-form"
             submitButtonText="Confirm"
             title="Delete Type"
             handleClose={props.handleClose}
@@ -21,7 +21,7 @@ const DeleteRequestTypeDialog: FunctionComponent<Props> = (props: Props) => {
             onSubmit={props.onSubmit}
             onCancel={props.onCancel}
         >
-            <div className="delete-request-type-form-content">
+            <div>
                 <p>
                     Are you sure you want to delete the group <b>&#34;{props.requestGroupName ?? "this"}&#34;</b>? This will delete the{" "}
                     <b>{props.numRequests}</b> requests in this group and cannot be undone.

--- a/client/src/components/organisms/DeleteRequestGroupDialog.tsx
+++ b/client/src/components/organisms/DeleteRequestGroupDialog.tsx
@@ -1,0 +1,34 @@
+import React, { FunctionComponent } from "react";
+
+import FormModal from "./FormModal";
+
+interface Props {
+    requestGroupName?: string;
+    handleClose: () => void;
+    onSubmit: (e: React.FormEvent) => void;
+    onCancel: () => void;
+    numRequests: number;
+}
+
+const DeleteRequestTypeDialog: FunctionComponent<Props> = (props: Props) => {
+    return (
+        <FormModal
+            className="delete-request-type-form"
+            submitButtonText="Confirm"
+            title="Delete Type"
+            handleClose={props.handleClose}
+            show={true}
+            onSubmit={props.onSubmit}
+            onCancel={props.onCancel}
+        >
+            <div className="delete-request-type-form-content">
+                <p>
+                    Are you sure you want to delete the group <b>&#34;{props.requestGroupName ?? "this"}&#34;</b>? This will delete the{" "}
+                    <b>{props.numRequests}</b> requests in this group and cannot be undone.
+                </p>
+            </div>
+        </FormModal>
+    );
+};
+
+export default DeleteRequestTypeDialog;

--- a/client/src/components/organisms/style/DeleteRequestGroupDialog.scss
+++ b/client/src/components/organisms/style/DeleteRequestGroupDialog.scss
@@ -1,0 +1,5 @@
+.delete-request-group-form {
+  p {
+      margin: 0;
+  }
+}

--- a/client/src/components/organisms/style/index.scss
+++ b/client/src/components/organisms/style/index.scss
@@ -12,6 +12,7 @@
 @import "RequestTypeForm";
 @import "FormModal";
 @import "LogoModal";
+@import "DeleteRequestGroupDialog";
 @import "DeleteRequestTypeDialog";
 @import "DonorImpactSection";
 @import "DonorHomepageBanner";

--- a/server/api/resolvers/requestGroupResolvers.ts
+++ b/server/api/resolvers/requestGroupResolvers.ts
@@ -86,6 +86,8 @@ const requestGroupMutationResolvers = {
             return sessionHandler(async (session) => {
                 const requestGroup = await RequestGroup.findById(_id).session(session);
 
+                if (requestGroup == null) return requestGroup;
+
                 if (requestGroup.deletedAt != null) return requestGroup.save({ session: session });
 
                 requestGroup.deletedAt = new Date();

--- a/server/api/resolvers/requestResolvers.ts
+++ b/server/api/resolvers/requestResolvers.ts
@@ -96,6 +96,9 @@ const requestMutationResolvers = {
         return authenticateUser().then(async () => {
             return sessionHandler(async (session) => {
                 const request = await Request.findById(_id);
+
+                if (request == null) return request;
+
                 request.deletedAt = new Date();
                 await updateRequestEmbedingInRequestTypes(request, session);
                 return request.save({ session: session });

--- a/server/api/resolvers/requestTypeResolvers.ts
+++ b/server/api/resolvers/requestTypeResolvers.ts
@@ -128,6 +128,8 @@ const requestTypeMutationResolvers = {
             return sessionHandler(async (session) => {
                 const requestType = await RequestType.findById(_id).session(session);
 
+                if (requestType == null) return requestType;
+
                 if (requestType.deletedAt != null) return requestType.save({ session: session });
 
                 requestType.deletedAt = new Date();


### PR DESCRIPTION
Added:
- modal for confirmation on deleting a requestGroup on /request-group/:_id
- added dropdown delete button on /request-group/:_id
- added null checks for resolvers involved in deleting

![image](https://user-images.githubusercontent.com/32274856/127797550-767a92f7-f88e-41ed-8447-64633bcd14dd.png)
