### PR TITLE
Edit RequestForm exiting without changes, warning dialog text, searchableDropdown fixes

### DIFF
--- a/client/src/components/atoms/SearchableDropdown.tsx
+++ b/client/src/components/atoms/SearchableDropdown.tsx
@@ -27,15 +27,14 @@ const SearchableDropdown: FunctionComponent<Props> = (props: Props) => {
         // Case-insensitive alphabetical sort
         return a.toLowerCase().localeCompare(b.toLowerCase());
     });
-
     const [isDropdownOpened, setIsDropdownOpened] = useState(false);
     const [displayItems, setDisplayItems] = useState(sortedDropdownItems);
 
     const displayMatchingItems = (newSearchString: string) => {
         const newDisplayItems =
             newSearchString.length === 0
-                ? props.dropdownItems
-                : props.dropdownItems.filter((item) => searchStringMatches(newSearchString, item));
+                ? sortedDropdownItems
+                : sortedDropdownItems.filter((item) => searchStringMatches(newSearchString, item));
         setDisplayItems(newDisplayItems);
     };
 

--- a/client/src/components/organisms/RequestForm.tsx
+++ b/client/src/components/organisms/RequestForm.tsx
@@ -233,7 +233,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     };
 
     const onRequestGroupInputChange = (newRequestGroupInput: string) => {
-        setChangeMade(true);
+        if (newRequestGroupInput !== requestGroup?.name ?? "") setChangeMade(true);
         setRequestGroupInput(newRequestGroupInput);
     };
 
@@ -264,7 +264,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     };
 
     const onRequestTypeInputChange = (newRequestTypeInput: string) => {
-        setChangeMade(true);
+        if (newRequestTypeInput === requestType?.name ?? "") setChangeMade(true);
         setRequestTypeInput(newRequestTypeInput);
     };
 
@@ -340,7 +340,16 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     };
 
     const handleClose = () => {
-        if (changeMade) {
+        let sameValues = false;
+
+        if (   clientName === (initialRequest?.clientName ?? "")
+            && requestGroup?._id === initialRequest?.requestType?.requestGroup?._id
+            && requestType?._id === initialRequest?.requestType?._id
+            && quantity === (initialRequest?.quantity ?? 0)) {
+                sameValues = true;
+        }
+        
+        if (changeMade && !sameValues) {
             setShowAlertDialog(true);
         } else {
             props.handleClose();
@@ -360,7 +369,7 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
             onSubmit={onSubmit}
             onCancel={props.handleClose}
             alertDialogProps={{
-                dialogText: "This request has not been created yet.",
+                dialogText: "This request has not been saved yet.",
                 onExit: props.handleClose,
                 onStay: () => {
                     setShowAlertDialog(false);

--- a/client/src/components/organisms/RequestForm.tsx
+++ b/client/src/components/organisms/RequestForm.tsx
@@ -342,13 +342,14 @@ const RequestGroupForm: FunctionComponent<Props> = (props: Props) => {
     const handleClose = () => {
         let sameValues = false;
 
-        if (   clientName === (initialRequest?.clientName ?? "")
+        if ( props.operation === "edit" 
+            && clientName === (initialRequest?.clientName ?? "")
             && requestGroup?._id === initialRequest?.requestType?.requestGroup?._id
             && requestType?._id === initialRequest?.requestType?._id
             && quantity === (initialRequest?.quantity ?? 0)) {
                 sameValues = true;
         }
-        
+
         if (changeMade && !sameValues) {
             setShowAlertDialog(true);
         } else {


### PR DESCRIPTION
Changed text in RequestForm when exiting with changes to say "This request has not been saved yet" instead of "This request has not been created yet".

Prevented error message (warning dialog) from showing up if no changes are made when in "edit" mode.

Fixed an issue with searchableDropdown failing to correctly load displayItems.