### PR TITLE
For Needs table - reduced latency, added loading spinners

### DIFF
--- a/client/src/components/molecules/RequestGroupTable.tsx
+++ b/client/src/components/molecules/RequestGroupTable.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useState } from "react";
 import moment from "moment";
+import { Spinner } from "react-bootstrap";
 import { useHistory } from "react-router-dom";
 
 import Tag from "../atoms/Tag";
@@ -9,6 +10,7 @@ import RequestGroupForm from "../organisms/RequestGroupForm";
 
 export interface Props {
     requestGroups: Array<RequestGroup> | undefined;
+    countRequestGroups: number;
 }
 
 const RequestGroupTable: FunctionComponent<Props> = (props: Props) => {
@@ -75,9 +77,8 @@ const RequestGroupTable: FunctionComponent<Props> = (props: Props) => {
                                 return g1.name < g2.name ? -1 : 1;
                             })
                             .map((requestGroup: RequestGroup) => (
-                                <>
+                                <React.Fragment key={requestGroup._id}>
                                     <tr
-                                        key={requestGroup._id}
                                         className="data-row"
                                         onClick={() => {
                                             history.push("/need/" + requestGroup._id);
@@ -118,7 +119,7 @@ const RequestGroupTable: FunctionComponent<Props> = (props: Props) => {
                                         </td>
                                         <td className="spacing-col" />
                                     </tr>
-                                    <tr className="border-row" key={requestGroup._id + "b"}>
+                                    <tr className="border-row">
                                         <td className="spacing-col" />
                                         <td>
                                             <div className="border-line" />
@@ -140,12 +141,16 @@ const RequestGroupTable: FunctionComponent<Props> = (props: Props) => {
                                         </td>
                                         <td className="spacing-col" />
                                     </tr>
-                                </>
+                                </React.Fragment>
                             ))}
                     </tbody>
                 )}
             </table>
-            {props.requestGroups && props.requestGroups.length == 0 && (
+            {props.requestGroups && props.requestGroups.length === 0 && props.countRequestGroups !== 0 && 
+                <div className="spinner">
+                    <Spinner animation="border" role="status" />
+                </div>}
+            {props.countRequestGroups === 0 && (
                 <span className="no-groups-msg">
                     There are no needs created.
                     <a

--- a/client/src/components/molecules/style/RequestGroupTable.scss
+++ b/client/src/components/molecules/style/RequestGroupTable.scss
@@ -143,4 +143,17 @@
             cursor: pointer;
         }
     }
+    
+    .spinner {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        height: 100vh;
+        width: 100vw;
+
+        .spinner-border {
+            width: 40px;
+            height: 40px;
+        }
+    }
 }

--- a/client/src/components/organisms/AdminRequestGroupList.tsx
+++ b/client/src/components/organisms/AdminRequestGroupList.tsx
@@ -1,6 +1,7 @@
 import { gql, useQuery } from "@apollo/client";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { Dropdown } from "react-bootstrap";
+import { Spinner } from "react-bootstrap";
 
 import RequestForm from "../organisms/RequestForm";
 import RequestGroup from "../../data/types/requestGroup";
@@ -11,6 +12,7 @@ import SimplePageNavigation from "../atoms/SimplePageNavigation";
 import { usePaginator } from "../utils/hooks";
 
 const AdminRequestGroupList: FunctionComponent = () => {
+    const [isLoading, setIsLoading] = useState(true);
     const [currentPage, setCurrentPage] = useState(0); // Indexing starting at 0.
     const [currentPageData, setCurrentPageData] = useState<Array<RequestGroup>>([]);
     const [showCreateRequestModal, setShowCreateRequestModal] = useState(false);
@@ -37,7 +39,7 @@ const AdminRequestGroupList: FunctionComponent = () => {
             }
         }
     `;
-    const paginator = usePaginator(numRequestGroupsPerPage, pages, getPageQuery, -1, 1);
+    const paginator = usePaginator(numRequestGroupsPerPage, pages, getPageQuery, -1, 0);
 
     const handlePageChange = (newPage: number) => {
         setCurrentPage(newPage);
@@ -50,6 +52,7 @@ const AdminRequestGroupList: FunctionComponent = () => {
     `;
 
     useEffect(() => {
+        if (countRequestGroups === 0) return;
         paginator.getPage(currentPage).then((page) => {
             setCurrentPageData(page);
         });
@@ -58,6 +61,7 @@ const AdminRequestGroupList: FunctionComponent = () => {
     useQuery(query, {
         onCompleted: (data: { countRequestGroups: number }) => {
             setCountRequestGroups(data.countRequestGroups);
+            setIsLoading(false);
         }
     });
 
@@ -131,7 +135,13 @@ const AdminRequestGroupList: FunctionComponent = () => {
                     onPageChange={(newPage) => handlePageChange(newPage - 1)}
                 />
             </div>
-            <RequestGroupTable requestGroups={currentPageData} />
+            {isLoading ?
+                <div className="spinner">
+                    <Spinner animation="border" role="status" />
+                </div>
+                :
+                <RequestGroupTable requestGroups={currentPageData} countRequestGroups={countRequestGroups} />
+            }
         </div>
     );
 };

--- a/client/src/components/organisms/style/AdminRequestGroupList.scss
+++ b/client/src/components/organisms/style/AdminRequestGroupList.scss
@@ -83,4 +83,17 @@
         margin-top: 24px;
         margin-bottom: 21px;
     }
+    
+    .spinner {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        height: 100vh;
+        width: 100vw;
+
+        .spinner-border {
+            width: 40px;
+            height: 40px;
+        }
+    }
 }

--- a/client/src/components/utils/hooks.ts
+++ b/client/src/components/utils/hooks.ts
@@ -101,7 +101,6 @@ const usePaginator = (
                     return [];
                 });
         }
-
         return pages.current.get(index) ?? [];
     };
 

--- a/server/api/resolvers/requestGroupResolvers.ts
+++ b/server/api/resolvers/requestGroupResolvers.ts
@@ -119,7 +119,7 @@ const requestGroupMutationResolvers = {
 const requestGroupResolvers = {
     requestTypes: async (parent, __, ___, info): Promise<Array<RequestTypeInterface>> => {
         // if we only want fields in the embedding, then pass the embedding along
-        if (infoContainsOnlyFields(info, ["_id"])) {
+        if (infoContainsOnlyFields(info, ["_id", "name", "deletedAt"])) {
             return parent.requestTypes;
         }
 

--- a/server/api/resolvers/requestResolvers.ts
+++ b/server/api/resolvers/requestResolvers.ts
@@ -6,9 +6,9 @@ import { sessionHandler } from "../utils/session";
 const requestEmbeddingFromRequest = (request: RequestInterface) => {
     return {
         _id: request._id,
-        createdAt: request.createdAt ? request.createdAt : null,
-        deletedAt: request.deletedAt ? request.deletedAt : null,
-        fulfilledAt: request.fulfilledAt ? request.fulfilledAt : null
+        createdAt: request.createdAt ?? null,
+        deletedAt: request.deletedAt ?? null,
+        fulfilledAt: request.fulfilledAt ?? null
     };
 };
 

--- a/server/api/resolvers/requestTypeResolvers.ts
+++ b/server/api/resolvers/requestTypeResolvers.ts
@@ -26,7 +26,9 @@ const filterDeletedRequestEmbeddings = (requestEmbeddings) => {
 
 const requestTypeEmbeddingFromRequestType = (requestType: RequestTypeInterface) => {
     return {
-        _id: requestType._id
+        _id: requestType._id,
+        name: requestType.name,
+        deletedAt: requestType.deletedAt ?? null
     };
 };
 

--- a/server/database/models/requestGroupModel.ts
+++ b/server/database/models/requestGroupModel.ts
@@ -2,6 +2,8 @@ import { Document, model, Schema, Types } from "mongoose";
 
 interface RequestTypeEmbeddingInterface {
     _id: Types.ObjectId;
+    name: string;
+    deletedAt: Date;
 }
 interface DonationFormEmbeddingInterface {
     _id: Types.ObjectId;
@@ -50,7 +52,9 @@ const RequestGroupSchema = new Schema(
             type: [
                 {
                     // @ts-ignore
-                    _id: { type: Types.ObjectId, ref: "RequestType" }
+                    _id: { type: Types.ObjectId, ref: "RequestType" },
+                    name: { type: String },
+                    deletedAt: { type: Date }
                 }
             ],
             default: []

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -245,7 +245,9 @@ connectDB(async () => {
             }
 
             requestGroup.requestTypes.push({
-                _id: requestType._id
+                _id: requestType._id,
+                name: requestType.name,
+                deletedAt: requestType.deletedAt
             });
 
             await requestType.save();


### PR DESCRIPTION
- Added name, deletedAt to requestType embeddfing in requestGroup to reduce latency by 1-1.5s
- Added above changes to seeder
- Added spinners to AdminRequestGroupList (main component of Needs page) and RequestGroupTable
- Fixed map->key issue in RequestGroupTable
- Removed prefetching pages 1 ahead/behind current page (saves 1-1.5s)

Currently, loading takes 2-3s (on reload page after initial load, takes just ms) for first page and 1-2s for second page (my guess is mongoose caches the results of .find(filter) in the page resolver making subsequent paging queries faster).
