### PR TITLE
fixed table width for RequestsTable

### DIFF
--- a/client/src/components/molecules/style/RequestTypeDropdown.scss
+++ b/client/src/components/molecules/style/RequestTypeDropdown.scss
@@ -50,6 +50,10 @@
         border-left: unset;
     }
 
+    .dropdown-body-open {
+        width: 100%;
+    }
+
     .button-container {
         background-color: #ededed;
         border-color: #ededed;

--- a/client/src/components/molecules/style/RequestsTable.scss
+++ b/client/src/components/molecules/style/RequestsTable.scss
@@ -1,13 +1,13 @@
 .request-table {
     @include table-base;
+    table-layout: fixed;
+    width: 100%;
+
     h1 {
         @include section-header-text;
         padding-bottom: 4px;
         margin: 0;
     }
-    width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
     .form-check-input {
         cursor: pointer;
     }


### PR DESCRIPTION
Width is responsive and keeps constant relative widths of columns. Width fits width of its container (the page in this case).

![image](https://user-images.githubusercontent.com/32274856/128442785-d68fc831-500d-4845-aa9e-23c33be4f2cb.png)
