### PR TITLE
GraphQL Resolver for Donor Homepage Config

### DIFF
--- a/server/api/resolvers.ts
+++ b/server/api/resolvers.ts
@@ -21,6 +21,8 @@ import {
 
 import { emailResolvers } from "./resolvers/emailResolvers";
 
+import {donorHomepageMutationResolvers, donorHomepageQueryResolvers } from "./resolvers/donorHomepageResolvers"
+
 const resolvers = {
     DonationItemCondition,
     DonationItemStatus,
@@ -29,7 +31,8 @@ const resolvers = {
         ...donationFormQueryResolvers,
         ...requestQueryResolvers,
         ...requestTypeQueryResolvers,
-        ...requestGroupQueryResolvers
+        ...requestGroupQueryResolvers,
+        ...donorHomepageQueryResolvers
     },
 
     Mutation: {
@@ -37,7 +40,8 @@ const resolvers = {
         ...requestMutationResolvers,
         ...requestTypeMutationResolvers,
         ...requestGroupMutationResolvers,
-        ...emailResolvers
+        ...emailResolvers,
+        ...donorHomepageMutationResolvers
     },
 
     Request: {
@@ -54,7 +58,7 @@ const resolvers = {
 
     DonationForm: {
         ...donationFormResolvers
-    }
+    },
 };
 
 export { resolvers };

--- a/server/api/resolvers.ts
+++ b/server/api/resolvers.ts
@@ -17,7 +17,7 @@ import {
     requestTypeMutationResolvers,
     requestTypeQueryResolvers,
     requestTypeResolvers
-} from "./resolvers/requestTypeResolvers";
+} from "./resolvers/requestTypeResolvers"; 
 
 import { emailResolvers } from "./resolvers/emailResolvers";
 

--- a/server/api/resolvers.ts
+++ b/server/api/resolvers.ts
@@ -17,7 +17,7 @@ import {
     requestTypeMutationResolvers,
     requestTypeQueryResolvers,
     requestTypeResolvers
-} from "./resolvers/requestTypeResolvers"; 
+} from "./resolvers/requestTypeResolvers";
 
 import { emailResolvers } from "./resolvers/emailResolvers";
 

--- a/server/api/resolvers.ts
+++ b/server/api/resolvers.ts
@@ -21,7 +21,7 @@ import {
 
 import { emailResolvers } from "./resolvers/emailResolvers";
 
-import {donorHomepageMutationResolvers, donorHomepageQueryResolvers } from "./resolvers/donorHomepageResolvers"
+import { donorHomepageMutationResolvers, donorHomepageQueryResolvers } from "./resolvers/donorHomepageResolvers";
 
 const resolvers = {
     DonationItemCondition,
@@ -58,7 +58,7 @@ const resolvers = {
 
     DonationForm: {
         ...donationFormResolvers
-    },
+    }
 };
 
 export { resolvers };

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -45,11 +45,12 @@ const donorHomepageMutationResolvers = {
 
             const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
             statistics.forEach((statistic) => {
-                statMeasurements.forEach((statMeasurement) => {
+                for (const statMeasurement of statMeasurements) {
                     if (statistic.type === statMeasurement.type) {
                         statistic.measurement = statMeasurement.measurement;
+                        break;
                     }
-                });
+                }
             });
 
             const donorHomepage = {

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -43,7 +43,7 @@ const donorHomepageMutationResolvers = {
             const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
             statistics.forEach((statistic) => {
                 const type = statistic.type.toString();
-                if (statMeasurements[type] !== "" && statMeasurements[type] === null) {
+                if (statMeasurements[type] !== "" && statMeasurements[type] !== null) {
                     statistic.measurement = statMeasurements[type];
                 }
             });

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -1,0 +1,65 @@
+import {
+    Banner,
+    DonorHomepage,
+    DonorHomepageInterface,
+    Map,
+    Statistic,
+    StatisticMeasurement,
+    Testimonial,
+    TestimonialCarousel
+} from "../../database/models/donorHomepageModel";
+
+const getDonorHomepageData = async <Type>(property: string): Promise<Type> => {
+    return DonorHomepage.find()
+        .exec()
+        .then((donorHomepageData) => {
+            return donorHomepageData[0][property];
+        });
+};
+
+const donorHomepageQueryResolvers = {
+    donorHomepageBanner: async (): Promise<Banner> => {
+        return getDonorHomepageData<Banner>("banner");
+    },
+    donorHomepageTestimonialCarousel: async (): Promise<TestimonialCarousel> => {
+        return getDonorHomepageData<TestimonialCarousel>("testimonialCarousel");
+    },
+    donorHomepageMap: async (): Promise<Map> => {
+        return getDonorHomepageData<Map>("map");
+    },
+    donorHomepageStatistics: async (): Promise<Array<Statistic>> => {
+        return getDonorHomepageData<Array<Statistic>>("statistics");
+    }
+};
+
+const donorHomepageMutationResolvers = {
+    updatedonorHomepageBanner: async (
+        mapTestimonials: Array<Testimonial>,
+        testimonialCarousel: TestimonialCarousel,
+        statMeasurements: Array<StatisticMeasurement>,
+        { authenticateUser }
+    ): Promise<DonorHomepageInterface> => {
+        return authenticateUser().then(async () => {
+            const map = await donorHomepageQueryResolvers.donorHomepageMap();
+            map.testimonials = mapTestimonials;
+
+            const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
+            statistics.forEach((statistic) => {
+                statMeasurements.forEach((statMeasurement) => {
+                    if (statistic.type === statMeasurement.type) {
+                        statistic.measurement = statMeasurement.measurement;
+                    }
+                });
+            });
+
+            const donorHomepage = {
+                map: map,
+                statistics: statistics,
+                testimonialCarousel: testimonialCarousel
+            };
+            return DonorHomepage.findOneAndUpdate({}, donorHomepage);
+        });
+    }
+};
+
+export { donorHomepageMutationResolvers, donorHomepageQueryResolvers };

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -45,11 +45,9 @@ const donorHomepageMutationResolvers = {
 
             const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
             statistics.forEach((statistic) => {
-                for (const statMeasurement of statMeasurements) {
-                    if (statistic.type === statMeasurement.type) {
-                        statistic.measurement = statMeasurement.measurement;
-                        break;
-                    }
+                const type = statistic.type.toString();
+                if (statMeasurements[type] !== "") {
+                    statistic.measurement = statMeasurements[type];
                 }
             });
 

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -43,7 +43,7 @@ const donorHomepageMutationResolvers = {
             const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
             statistics.forEach((statistic) => {
                 const type = statistic.type.toString();
-                if (statMeasurements[type] !== "" && statMeasurements[type] !== null) {
+                if (statMeasurements[type] !== "" && statMeasurements[type] != null) {
                     statistic.measurement = statMeasurements[type];
                 }
             });

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -4,8 +4,6 @@ import {
     DonorHomepageInterface,
     Map,
     Statistic,
-    StatisticMeasurement,
-    Testimonial,
     TestimonialCarousel
 } from "../../database/models/donorHomepageModel";
 
@@ -45,7 +43,7 @@ const donorHomepageMutationResolvers = {
             const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
             statistics.forEach((statistic) => {
                 const type = statistic.type.toString();
-                if (statMeasurements[type] !== "" || statMeasurements[type] === null) {
+                if (statMeasurements[type] !== "" && statMeasurements[type] === null) {
                     statistic.measurement = statMeasurements[type];
                 }
             });

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -45,7 +45,7 @@ const donorHomepageMutationResolvers = {
             const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
             statistics.forEach((statistic) => {
                 const type = statistic.type.toString();
-                if (statMeasurements[type] !== "") {
+                if (statMeasurements[type] !== "" || statMeasurements[type] === null) {
                     statistic.measurement = statMeasurements[type];
                 }
             });

--- a/server/api/resolvers/donorHomepageResolvers.ts
+++ b/server/api/resolvers/donorHomepageResolvers.ts
@@ -33,10 +33,9 @@ const donorHomepageQueryResolvers = {
 };
 
 const donorHomepageMutationResolvers = {
-    updatedonorHomepageBanner: async (
-        mapTestimonials: Array<Testimonial>,
-        testimonialCarousel: TestimonialCarousel,
-        statMeasurements: Array<StatisticMeasurement>,
+    updateDonorHomepage: async (
+        _,
+        { mapTestimonials, carouselTestimonials, statMeasurements },
         { authenticateUser }
     ): Promise<DonorHomepageInterface> => {
         return authenticateUser().then(async () => {
@@ -50,6 +49,9 @@ const donorHomepageMutationResolvers = {
                     statistic.measurement = statMeasurements[type];
                 }
             });
+            
+            const testimonialCarousel = await donorHomepageQueryResolvers.donorHomepageTestimonialCarousel();
+            testimonialCarousel.testimonials = carouselTestimonials;
 
             const donorHomepage = {
                 map: map,

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -245,8 +245,9 @@ const typeDefs = gql`
     }
 
     input StatisticMeasurement {
-        measurement: String
-        type: StatisticType!
+        REGULAR_DONORS: String,
+        DIAPERS_DISTRIBUTED: String,
+        CARE_CLOSET_VISITS: String
     }
 
     type TestimonialCarousel {
@@ -338,7 +339,7 @@ const typeDefs = gql`
         updateDonorHomepage(
             mapTestimonials: [Testimonial!]
             testimonialCarousel: [Testimonial!]
-            statMeasurements: [StatisticMeasurement]
+            statMeasurements: StatisticMeasurement
         ): DonorHomepage
     }
 `;

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -283,7 +283,6 @@ const typeDefs = gql`
         ): [DonationForm]
 
         donorHomepage: DonorHomepage
-        
     }
 
     type Mutation {

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -214,12 +214,18 @@ const typeDefs = gql`
     }
 
     type MapPoint {
-        x: Int!
-        y: Int!
+        x: Float!
+        y: Float!
     }
 
     type Testimonial {
-        id: Int!
+        id: Int
+        imagePath: String
+        testimonial: String
+    }
+
+    input TestimonialInput {
+        id: Int
         imagePath: String
         testimonial: String
     }
@@ -252,7 +258,7 @@ const typeDefs = gql`
 
     type TestimonialCarousel {
         testimonials: [Testimonial]
-        interval: Int
+        interval: Int!
     }
 
     type Banner {
@@ -265,9 +271,9 @@ const typeDefs = gql`
     type DonorHomepage {
         _id: ID!
         map: Map!
-        statistics: [Statistic]
+        statistics: [Statistic]!
         banner: Banner!
-        testimonialCarousel: [TestimonialCarousel]
+        testimonialCarousel: TestimonialCarousel!
     }
 
     type Query {
@@ -306,7 +312,7 @@ const typeDefs = gql`
         donorHomepageBanner: Banner
         donorHomepageTestimonialCarousel: TestimonialCarousel
         donorHomepageMap: Map
-        donorHomepageStats: [Statistic]
+        donorHomepageStatistics: [Statistic]
     }
 
     type Mutation {
@@ -337,8 +343,8 @@ const typeDefs = gql`
         sendRejectionEmail(id: ID): String
 
         updateDonorHomepage(
-            mapTestimonials: [Testimonial!]
-            testimonialCarousel: [Testimonial!]
+            mapTestimonials: [TestimonialInput!]
+            carouselTestimonials: [TestimonialInput!]
             statMeasurements: StatisticMeasurement
         ): DonorHomepage
     }

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -231,10 +231,22 @@ const typeDefs = gql`
         testimonials: [Testimonial]
     }
 
+    enum StatisticType {
+        REGULAR_DONORS
+        DIAPERS_DISTRIBUTED
+        CARE_CLOSET_VISITS
+    }
+
     type Statistic {
-        icon: String
+        icon: String!
+        measurement: String!
+        stat: String!
+        type: StatisticType!
+    }
+
+    input StatisticMeasurement {
         measurement: String
-        stat: String
+        type: StatisticType!
     }
 
     type TestimonialCarousel {
@@ -255,17 +267,6 @@ const typeDefs = gql`
         statistics: [Statistic]
         banner: Banner!
         testimonialCarousel: [TestimonialCarousel]
-    }
-
-    enum StatisticType {
-        REGULAR_DONORS
-        DIAPERS_DISTRIBUTED
-        CARE_CLOSET_VISITS
-    }
-
-    input StatisticMeasurement {
-        measurement: String
-        type: StatisticType!
     }
 
     type Query {
@@ -334,7 +335,11 @@ const typeDefs = gql`
         sendApprovalEmail(id: ID): String
         sendRejectionEmail(id: ID): String
 
-        updateDonorHomepage(mapTestimonials : [Testimonial!]!, testimonialCarousel : [Testimonial!], measurements : [StatisticMeasurement]) : DonorHomepage
+        updateDonorHomepage(
+            mapTestimonials: [Testimonial!]!
+            testimonialCarousel: [Testimonial!]
+            statMeasurements: [StatisticMeasurement]
+        ): DonorHomepage
     }
 `;
 

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -219,16 +219,15 @@ const typeDefs = gql`
         y: Int!
     }
 
-    type MapTestimonial {
+    type Testimonial {
         id: Int!
         imagePath: String
         testimonial: String
     }
 
-
     type Map {
         points: [MapPoint]!
-        testimonials: [MapTestimonial]
+        testimonials: [Testimonial]
     }
 
     type Statistic {
@@ -237,20 +236,14 @@ const typeDefs = gql`
         stat: String
     }
 
-    type ClientTestimonial {
-        id: Int!
-        imagePath: String
-        testimonial: String
-    }
-
     type TestimonialCarousel {
-        testimonials: [ClientTestimonial]
+        testimonials: [Testimonial]
         interval: Int
     }
 
-    type donorHomepage {
+    type DonorHomepage {
         _id: ID!
-        map: Map
+        map: Map!
         statistics: [Statistic]
         banner: Banner
         testimonialCarousel: [TestimonialCarousel]
@@ -288,6 +281,9 @@ const typeDefs = gql`
             filterOptions: DonationFormFilterOptions
             sortBy: DonationFormSortOptions
         ): [DonationForm]
+
+        donorHomepage: DonorHomepage
+        
     }
 
     type Mutation {

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -245,8 +245,8 @@ const typeDefs = gql`
     }
 
     input StatisticMeasurement {
-        REGULAR_DONORS: String,
-        DIAPERS_DISTRIBUTED: String,
+        REGULAR_DONORS: String
+        DIAPERS_DISTRIBUTED: String
         CARE_CLOSET_VISITS: String
     }
 

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -213,6 +213,49 @@ const typeDefs = gql`
         matchedAt: String
     }
 
+    type MapPoint {
+        markerSize: String!
+        x: Int!
+        y: Int!
+    }
+
+    type MapTestimonial {
+        id: Int!
+        imagePath: String
+        testimonial: String
+    }
+
+
+    type Map {
+        points: [MapPoint]!
+        testimonials: [MapTestimonial]
+    }
+
+    type Statistic {
+        icon: String
+        measurement: String
+        stat: String
+    }
+
+    type ClientTestimonial {
+        id: Int!
+        imagePath: String
+        testimonial: String
+    }
+
+    type TestimonialCarousel {
+        testimonials: [ClientTestimonial]
+        interval: Int
+    }
+
+    type donorHomepage {
+        _id: ID!
+        map: Map
+        statistics: [Statistic]
+        banner: Banner
+        testimonialCarousel: [TestimonialCarousel]
+    }
+
     type Query {
         request(_id: ID): Request
         requests: [Request]

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -214,7 +214,6 @@ const typeDefs = gql`
     }
 
     type MapPoint {
-        markerSize: String!
         x: Int!
         y: Int!
     }
@@ -226,6 +225,8 @@ const typeDefs = gql`
     }
 
     type Map {
+        defaultMarkerSize: String!
+        markerSizes: [String]!
         points: [MapPoint]!
         testimonials: [Testimonial]
     }
@@ -241,12 +242,30 @@ const typeDefs = gql`
         interval: Int
     }
 
+    type Banner {
+        header: String!
+        description: String!
+        imagePaths: [String]!
+        interval: Int!
+    }
+
     type DonorHomepage {
         _id: ID!
         map: Map!
         statistics: [Statistic]
-        banner: Banner
+        banner: Banner!
         testimonialCarousel: [TestimonialCarousel]
+    }
+
+    enum StatisticType {
+        REGULAR_DONORS
+        DIAPERS_DISTRIBUTED
+        CARE_CLOSET_VISITS
+    }
+
+    input StatisticMeasurement {
+        measurement: String
+        type: StatisticType!
     }
 
     type Query {
@@ -282,7 +301,10 @@ const typeDefs = gql`
             sortBy: DonationFormSortOptions
         ): [DonationForm]
 
-        donorHomepage: DonorHomepage
+        donorHomepageBanner: Banner
+        donorHomepageTestimonialCarousel: TestimonialCarousel
+        donorHomepageMap: Map
+        donorHomepageStats: [Statistic]
     }
 
     type Mutation {
@@ -311,6 +333,8 @@ const typeDefs = gql`
         sendConfirmationEmail(ids: [ID]): String
         sendApprovalEmail(id: ID): String
         sendRejectionEmail(id: ID): String
+
+        updateDonorHomepage(mapTestimonials : [Testimonial!]!, testimonialCarousel : [Testimonial!], measurements : [StatisticMeasurement]) : DonorHomepage
     }
 `;
 

--- a/server/api/schema.ts
+++ b/server/api/schema.ts
@@ -336,7 +336,7 @@ const typeDefs = gql`
         sendRejectionEmail(id: ID): String
 
         updateDonorHomepage(
-            mapTestimonials: [Testimonial!]!
+            mapTestimonials: [Testimonial!]
             testimonialCarousel: [Testimonial!]
             statMeasurements: [StatisticMeasurement]
         ): DonorHomepage

--- a/server/database/models/donorHomepageModel.ts
+++ b/server/database/models/donorHomepageModel.ts
@@ -5,6 +5,31 @@ interface MapPoint {
     y: number;
 }
 
+interface Testimonial {
+    id: number;
+    imagePath: string;
+    testimonial: string;
+}
+
+interface Banner {
+    header: string;
+    description: string;
+    imagePaths: Array<string>;
+    interval: number;
+}
+
+interface TestimonialCarousel {
+    testimonials: Array<Testimonial>;
+    interval: number;
+}
+
+interface Map {
+    defaultMarkerSize: string;
+    markerSizes: Array<string>;
+    points: Array<MapPoint>;
+    testimonials: Array<Testimonial>;
+}
+
 enum StatisticType {
     REGULAR_DONORS = "REGULAR_DONORS",
     DIAPERS_DISTRIBUTED = "DIAPERS_DISTRIBUTED",
@@ -18,33 +43,19 @@ interface Statistic {
     type: StatisticType;
 }
 
-interface Testimonial {
-    id: number;
-    imagePath: string;
-    testimonial: string;
+interface StatisticMeasurement {
+    measurement: string;
+    type: StatisticType;
 }
 
 interface DonorHomepageInterface extends Document {
     _id: Types.ObjectId;
 
     // Properties
-    map: {
-        defaultMarkerSize: string;
-        markerSizes: Array<string>;
-        points: Array<MapPoint>;
-        testimonials: Array<Testimonial>;
-    };
+    map: Map;
     statistics: Array<Statistic>;
-    banner: {
-        header: string;
-        description: string;
-        imagePaths: Array<string>;
-        interval: number;
-    };
-    testimonialCarousel: {
-        testimonials: Array<Testimonial>;
-        interval: number;
-    };
+    banner: Banner;
+    testimonialCarousel: TestimonialCarousel;
 }
 
 const DonorHomepageSchema = new Schema({
@@ -115,4 +126,15 @@ const DonorHomepageSchema = new Schema({
 });
 
 const DonorHomepage = model<DonorHomepageInterface>("DonorHomepage", DonorHomepageSchema);
-export { DonorHomepage, DonorHomepageInterface, MapPoint, Statistic, Testimonial, StatisticType };
+export {
+    DonorHomepage,
+    DonorHomepageInterface,
+    MapPoint,
+    Statistic,
+    Testimonial,
+    StatisticMeasurement,
+    StatisticType,
+    Map,
+    Banner,
+    TestimonialCarousel
+};

--- a/server/database/models/donorHomepageModel.ts
+++ b/server/database/models/donorHomepageModel.ts
@@ -44,8 +44,9 @@ interface Statistic {
 }
 
 interface StatisticMeasurement {
-    measurement: string;
-    type: StatisticType;
+    REGULAR_DONORS: string;
+    DIAPERS_DISTRIBUTED: string;
+    CARE_CLOSET_VISITS: string;
 }
 
 interface DonorHomepageInterface extends Document {


### PR DESCRIPTION
### 🛠 Work Done:
- Added donor homepage config to schema.ts
- Created basic mutation and query resolvers
- Updated mongoose model + schema.ts so statistics have a type field
- Registered resolvers

### 🧐 Things to double check
1. Mutation resolver
2. Type vs Input in schema.ts

**COMMENTS ON MUTATION RESOLVER**
- I feel like if our # of statistics scaled for some reason, the double for loop that cross-compares types would not be very efficient 
- A more efficient solution might be to make statMeasurements obj whose fields correspond to StatisticTypes?

```
# schema.ts
input statMeasurement {
    REGULAR_DONORS: string;
    ...
}
```
so that when updating each statistic in the config it would be more efficient than comparing the types of an array of StatisticMeasurement since we could just do:

````
const statistics = await donorHomepageQueryResolvers.donorHomepageStatistics();
statistics.forEach((statistic) => {
    const statType = statistic.type.toString();
    if (statMeasurement[statType] != "") {
        statistic.measurement = statMeasurement[statType];
    }
}); 