### PR TITLE
Bugfix for unintentional admin logout

### DIFF
--- a/client/src/components/organisms/AdminRequestGroupBrowser.tsx
+++ b/client/src/components/organisms/AdminRequestGroupBrowser.tsx
@@ -87,8 +87,7 @@ const AdminRequestGroupBrowser: FunctionComponent = () => {
 
     const deleteRequestGroup = async () => {
         await mutateDeleteRequestGroup({ variables: { id: requestGroup?._id } });
-        // replace current page in browser so user cannot go back to non-existent requestGroup page
-        history.replace("/admin");
+        history.goBack();
     };
 
     return (


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/Bug-When-Editing-a-Request-or-Request-Type-the-admin-logs-out-e2c07fad77d34172ae2c80ebafee6ad8)

Fixed bug where deleting a request group would redirect user to donor homepage (logging them out)


https://user-images.githubusercontent.com/45080644/131237930-99df5c59-8c5c-4f2c-a87a-d479c5756f1c.mp4

