### PR TITLE
Add warning for deleting requestypes

### DIFF
--- a/client/src/components/atoms/style/SearchableDropdown.scss
+++ b/client/src/components/atoms/style/SearchableDropdown.scss
@@ -9,7 +9,7 @@
         margin-bottom: 5px;
         width: 100%;
     }
-    
+
     .dropdown-action {
         @include normal-text;
         font-size: 14px;

--- a/client/src/components/atoms/style/WarningDialog.scss
+++ b/client/src/components/atoms/style/WarningDialog.scss
@@ -1,10 +1,10 @@
 .warning-dialog {
     display: block;
-
+    z-index: 1;
     position: fixed;
     top: 0;
     left: 37%;
-    width: 25%;
+    width: 29%;
     border-radius: 4px;
     background-color: $alert-light-color;
     color: $alert-dark-color;
@@ -16,7 +16,8 @@
     }
 
     .warning-dialog-buttons {
-        margin-left: 83%;
+        margin-top: 2%;
+        margin-left: 80%;
     }
 
     .warning-leave-button {

--- a/client/src/components/molecules/RequestTypeDropdown.tsx
+++ b/client/src/components/molecules/RequestTypeDropdown.tsx
@@ -74,27 +74,26 @@ const RequestTypeDropdown: FunctionComponent<Props> = (props: Props) => {
     const handleDeleteRequestType = () => {
         setDeleteModalShow(false);
         let canDelete = true;
-        if(requestType && requestType.requests) {
-            requestType.requests.forEach(request => {
-                if(!request.fulfilledAt) {
-                    if(request.matchedDonations) {
-                        request.matchedDonations.forEach(item => {
-                            if(item.quantity > 0) {
+        if (requestType && requestType.requests) {
+            requestType.requests.forEach((request) => {
+                if (!request.fulfilledAt) {
+                    if (request.matchedDonations) {
+                        request.matchedDonations.forEach((item) => {
+                            if (item.quantity > 0) {
                                 canDelete = false;
                             }
-                        })
+                        });
                     }
                 }
-            })
+            });
         }
-        if(canDelete) {
+        if (canDelete) {
             deleteRequestType();
             window.location.reload();
-        }
-        else {
+        } else {
             setShowWarningDialog(true);
         }
-    }
+    };
 
     useEffect(() => {
         setNumRequests(props.requests!.reduce((total, request) => (request.deletedAt == null ? total + 1 : total), 0));

--- a/client/src/components/molecules/RequestTypeDropdown.tsx
+++ b/client/src/components/molecules/RequestTypeDropdown.tsx
@@ -8,6 +8,7 @@ import RequestGroup from "../../data/types/requestGroup";
 import RequestsTable from "./RequestsTable";
 import RequestType from "../../data/types/requestType";
 import RequestTypeForm from "../organisms/RequestTypeForm";
+import WarningDialog from "../atoms/WarningDialog";
 
 interface Props {
     key?: string;
@@ -19,6 +20,7 @@ interface Props {
 
 const RequestTypeDropdown: FunctionComponent<Props> = (props: Props) => {
     const [numRequests, setNumRequests] = useState(0);
+    const [showWarningDialog, setShowWarningDialog] = useState(false);
 
     const softDelete = gql`
         mutation deleteRequestType($id: ID) {
@@ -69,6 +71,31 @@ const RequestTypeDropdown: FunctionComponent<Props> = (props: Props) => {
         setDeleteModalShow(true);
     };
 
+    const handleDeleteRequestType = () => {
+        setDeleteModalShow(false);
+        let canDelete = true;
+        if(requestType && requestType.requests) {
+            requestType.requests.forEach(request => {
+                if(!request.fulfilledAt) {
+                    if(request.matchedDonations) {
+                        request.matchedDonations.forEach(item => {
+                            if(item.quantity > 0) {
+                                canDelete = false;
+                            }
+                        })
+                    }
+                }
+            })
+        }
+        if(canDelete) {
+            deleteRequestType();
+            window.location.reload();
+        }
+        else {
+            setShowWarningDialog(true);
+        }
+    }
+
     useEffect(() => {
         setNumRequests(props.requests!.reduce((total, request) => (request.deletedAt == null ? total + 1 : total), 0));
     }, []);
@@ -78,6 +105,13 @@ const RequestTypeDropdown: FunctionComponent<Props> = (props: Props) => {
     };
     return (
         <div className="request-type-dropdown-container">
+            {showWarningDialog && (
+                <WarningDialog
+                    dialogTitle="This request type has unfulfilled requests with attached donation forms."
+                    dialogText="It cannot be deleted until the amount contributed by all donation forms to the requests is zero."
+                    onClose={() => setShowWarningDialog(false)}
+                />
+            )}
             <Dropdown
                 title={requestType?.name ? requestType.name.toUpperCase() + " (" + numRequests + ")" : ""}
                 header={
@@ -126,8 +160,7 @@ const RequestTypeDropdown: FunctionComponent<Props> = (props: Props) => {
                     requestGroupName={props.requestGroup!.name}
                     handleClose={() => setDeleteModalShow(false)}
                     onSubmit={() => {
-                        deleteRequestType();
-                        window.location.reload();
+                        handleDeleteRequestType();
                     }}
                     onCancel={() => setDeleteModalShow(false)}
                     numRequests={getTotalCountRequests()}


### PR DESCRIPTION
[Notion ticket](https://www.notion.so/uwblueprintexecs/Show-warning-dialog-when-deleting-requesttype-with-requests-with-donation-forms-1061a29583ef468ab382e9697e92886e)
- If requestType contains unfulfilled request that contains donation forms that contribute > 0 quantity, a warning is now displayed when you try to delete this requestType