### PR TITLE
Saving changes to donor homepage config

### DIFF
--- a/client/src/components/atoms/EditTestimonialCard.tsx
+++ b/client/src/components/atoms/EditTestimonialCard.tsx
@@ -38,6 +38,7 @@ const EditTestimonialCard: FunctionComponent<Props> = (props: Props) => {
             error = true;
         }
         if (testimonial.length < minNumChars) {
+
             setTestimonialError(true);
             error = true;
         }

--- a/client/src/components/atoms/EditTestimonialCard.tsx
+++ b/client/src/components/atoms/EditTestimonialCard.tsx
@@ -79,7 +79,7 @@ const EditTestimonialCard: FunctionComponent<Props> = (props: Props) => {
                 />
                 {testimonialError && <p className="error-text"> Please enter at least {minNumChars} characters.</p>}
                 <div className="buttons">
-                    <Button className="update-button" text="Update" onClick={() => onUpdate} copyText="" />
+                    <Button className="update-button" text="Update" onClick={onUpdate} copyText="" />
                     <Button
                         className="cancel-button"
                         text="Cancel"

--- a/client/src/components/atoms/style/TestimonialCard.scss
+++ b/client/src/components/atoms/style/TestimonialCard.scss
@@ -18,7 +18,6 @@
 
     .text {
         max-width: 310px;
-        word-break: break-all;
     }
 
     .action-icons {

--- a/client/src/components/molecules/EditStatisticsSection.tsx
+++ b/client/src/components/molecules/EditStatisticsSection.tsx
@@ -15,7 +15,7 @@ const capitalizeFirstLetter = (str: string) => {
 const EditStatisticsSection: FunctionComponent = () => {
     const { formState, setFormState } = useContext(EditTestimonialsContext);
     const { careClosetVisitsStatError, diapersDistributedStatError, regularDonorsStatError } = formState;
-
+    
     const findStat = (statType: StatisticType) =>
         formState.donorHomepageConfig.statistics.find((stat) => stat.type === statType);
 

--- a/client/src/components/molecules/EditStatisticsSection.tsx
+++ b/client/src/components/molecules/EditStatisticsSection.tsx
@@ -15,10 +15,10 @@ const capitalizeFirstLetter = (str: string) => {
 const EditStatisticsSection: FunctionComponent = () => {
     const { formState, setFormState } = useContext(EditTestimonialsContext);
     const { careClosetVisitsStatError, diapersDistributedStatError, regularDonorsStatError } = formState;
-    
+
     const findStat = (statType: StatisticType) => {
         return formState.donorHomepageConfig.statistics.find((stat) => stat.type === statType);
-    }
+    };
 
     const regularDonorsStat: Statistic | null = findStat(StatisticType.REGULAR_DONORS) ?? null;
     const diapersDistributedStat: Statistic | null = findStat(StatisticType.DIAPERS_DISTRIBUTED) ?? null;

--- a/client/src/components/molecules/EditStatisticsSection.tsx
+++ b/client/src/components/molecules/EditStatisticsSection.tsx
@@ -16,8 +16,9 @@ const EditStatisticsSection: FunctionComponent = () => {
     const { formState, setFormState } = useContext(EditTestimonialsContext);
     const { careClosetVisitsStatError, diapersDistributedStatError, regularDonorsStatError } = formState;
     
-    const findStat = (statType: StatisticType) =>
-        formState.donorHomepageConfig.statistics.find((stat) => stat.type === statType);
+    const findStat = (statType: StatisticType) => {
+        return formState.donorHomepageConfig.statistics.find((stat) => stat.type === statType);
+    }
 
     const regularDonorsStat: Statistic | null = findStat(StatisticType.REGULAR_DONORS) ?? null;
     const diapersDistributedStat: Statistic | null = findStat(StatisticType.DIAPERS_DISTRIBUTED) ?? null;

--- a/client/src/components/organisms/DonorImpactSection.tsx
+++ b/client/src/components/organisms/DonorImpactSection.tsx
@@ -3,11 +3,18 @@ import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
 
 import MapWithMarkers, { MapWithMarkersPoint } from "../atoms/MapWithMarkers";
-import { Statistic, Testimonial } from "../../data/types/donorHomepageConfig";
 import BaseMap from "../../assets/kw-region-map.png";
 import Card from "../atoms/CardWithShadow";
 import Cursor from "../../assets/cursor.png";
 import DonorHomepageConfig from "../../config/donorHomepageConfig.json";
+import { Testimonial } from "../../data/types/donorHomepageConfig";
+
+interface Statistic {
+    icon: string;
+    measurement: string;
+    stat: string;
+    type: string;
+}
 
 const DonorImpactSection: FunctionComponent = () => {
     const [selectedTestimonial, _setSelectedTestimonial] = useState<Testimonial | null>(null);
@@ -62,13 +69,13 @@ const DonorImpactSection: FunctionComponent = () => {
                 </Col>
                 <Col className="info-section" sm={12} xl={5}>
                     <div className="stats-section">
-                        {DonorHomepageConfig.statistics.map((stat: Statistic) => (
-                            <div className="stat" key={stat.icon}>
+                        {DonorHomepageConfig.statistics.map((statistic: Statistic) => (
+                            <div className="stat" key={statistic.icon}>
                                 <div className="stat-top">
-                                    <i className={stat.icon} />
-                                    <h1>{stat.measurement}</h1>
+                                    <i className={statistic.icon} />
+                                    <h1>{statistic.measurement}</h1>
                                 </div>
-                                <p>{stat.stat}</p>
+                                <p>{statistic.stat}</p>
                             </div>
                         ))}
                     </div>

--- a/client/src/data/types/donorHomepageConfig.ts
+++ b/client/src/data/types/donorHomepageConfig.ts
@@ -30,12 +30,6 @@ export interface DonorHomepageConfig {
         testimonials: Array<Testimonial>;
     };
     statistics: Array<Statistic>;
-    banner: {
-        header: string;
-        description: string;
-        imagePaths: Array<string>;
-        interval: number;
-    };
     testimonialCarousel: {
         testimonials: Array<Testimonial>;
         interval: number;

--- a/client/src/data/types/donorHomepageConfig.ts
+++ b/client/src/data/types/donorHomepageConfig.ts
@@ -19,7 +19,7 @@ export interface Statistic {
     icon: string;
     measurement: string;
     stat: string;
-    type: string;
+    type: StatisticType;
 }
 
 export interface DonorHomepageConfig {

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -120,7 +120,6 @@ const AdminEditTestimonialsPage: FunctionComponent = () => {
             const type = statistic.type.toString();
             statMeasurements[type] = statistic.measurement;
         });
-        console.log(statMeasurements); // ✅✅
         mutateDonorHomepageConfig({
             variables: {
                 mapTestimonials: formState.donorHomepageConfig.map.testimonials,

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -7,6 +7,7 @@ import { DonorHomepageConfig as DonorHomepageConfigType } from "../data/types/do
 import EditClientStoriesSection from "../components/molecules/EditClientStoriesSection";
 import EditStatisticsSection from "../components/molecules/EditStatisticsSection";
 import { Statistic } from "../data/types/donorHomepageConfig";
+import { useEffect } from "react";
 
 export type EditTestimonialsFormState = {
     careClosetVisitsStatError: string;

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -103,7 +103,7 @@ const AdminEditTestimonialsPage: FunctionComponent = () => {
         setTimeout(() => {
             setShowSuccessAlert(false);
         }, 5000);
-    }, [])
+    }, [showSuccessAlert])
 
     const handleSave = () => {
         console.log("save");

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -1,5 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
 import React, { FunctionComponent, useState } from "react";
+import { Statistic, StatisticType } from "../data/types/donorHomepageConfig"
 import AdminPage from "../components/layouts/AdminPage";
 import { Button } from "../components/atoms/Button";
 import DonorHomepageConfig from "../config/donorHomepageConfig.json";
@@ -45,14 +46,20 @@ const AdminEditTestimonialsPage: FunctionComponent = () => {
 
     const handleSave = () => {
         console.log("save");
+        const statistics = formState.donorHomepageConfig.statistics;
         const statMeasurements = {
             REGULAR_DONORS: "",
             DIAPERS_DISTRIBUTED: "",
             CARE_CLOSET_VISITS: ""
         }
+        statistics.forEach((statistic : Statistic) => {
+            const type = statistic.type.toString();
+            statMeasurements[type] = statistic.measurement;
+        })
         mutateDonorHomepageConfig({ variables: {
             mapTestimonials: formState.donorHomepageConfig.map.testimonials,
-            carouselTestimonials: formState.donorHomepageConfig.
+            carouselTestimonials: formState.donorHomepageConfig.testimonialCarousel.testimonials,
+            statMeasurements: statMeasurements
         } });
     };
 

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -1,12 +1,12 @@
-import { gql, useMutation } from "@apollo/client";
-import React, { FunctionComponent, useState } from "react";
-import { Statistic, StatisticType } from "../data/types/donorHomepageConfig"
+import { Alert, Spinner } from "react-bootstrap";
+import { gql, useMutation, useQuery } from "@apollo/client";
+import React, { FunctionComponent, useEffect, useState } from "react";
 import AdminPage from "../components/layouts/AdminPage";
 import { Button } from "../components/atoms/Button";
-import DonorHomepageConfig from "../config/donorHomepageConfig.json";
 import { DonorHomepageConfig as DonorHomepageConfigType } from "../data/types/donorHomepageConfig";
 import EditClientStoriesSection from "../components/molecules/EditClientStoriesSection";
 import EditStatisticsSection from "../components/molecules/EditStatisticsSection";
+import { Statistic } from "../data/types/donorHomepageConfig";
 
 export type EditTestimonialsFormState = {
     careClosetVisitsStatError: string;
@@ -16,68 +16,148 @@ export type EditTestimonialsFormState = {
     editingClientStory: boolean;
 };
 
-const initialFormState: EditTestimonialsFormState = {
-    careClosetVisitsStatError: "",
-    diapersDistributedStatError: "",
-    donorHomepageConfig: DonorHomepageConfig,
-    regularDonorsStatError: "",
-    editingClientStory: false
-};
-
 export const EditTestimonialsContext = React.createContext<{
     formState: EditTestimonialsFormState;
     setFormState: (newFormState: EditTestimonialsFormState) => void;
-}>({
-    formState: initialFormState,
-    setFormState: () => {}
-});
+}>(undefined!);
 
 const AdminEditTestimonialsPage: FunctionComponent = () => {
-    const [formState, setFormState] = useState<EditTestimonialsFormState>(initialFormState);
-    const updateDonorHomepageConfig = gql`
-        mutation UpdateDonorHomepage($mapTestimonials: [TestimonialInput], $carouselTestimonials: [TestimonialInput], $statMeasurements : StatisticMeasurement) {
-            updateDonorHomepage(mapTestimonials: $mapTestimonials, carouselTestimonials: $carouselTestimonials, statMeasurements: $statMeasurements) {
-                
+    const [formState, setFormState] = useState<EditTestimonialsFormState | undefined>(undefined);
+    const [showSuccessAlert, setShowSuccessAlert] = useState(false);
+    const query = gql`
+        query GetDonorHomepage {
+            donorHomepage {
+                map {
+                    testimonials {
+                        id
+                        imagePath
+                        testimonial
+                    }
+                }
+                statistics {
+                    icon
+                    measurement
+                    stat
+                    type
+                }
+                testimonialCarousel {
+                    testimonials {
+                        id
+                        imagePath
+                        testimonial
+                    }
+                }
             }
         }
     `;
-    const [mutateDonorHomepageConfig] = useMutation(updateDonorHomepageConfig);
+    const { error } = useQuery(query, {
+        onCompleted: (data: { donorHomepage: DonorHomepageConfigType }) => {
+            const res = JSON.parse(JSON.stringify(data.donorHomepage));
+            const initialFormState = {
+                careClosetVisitsStatError: "",
+                diapersDistributedStatError: "",
+                donorHomepageConfig: res,
+                regularDonorsStatError: "",
+                editingClientStory: false
+            };
+            setFormState(initialFormState);
+        }
+    });
+    if (error) console.log(error.graphQLErrors);
 
+    const updateDonorHomepageConfig = gql`
+        mutation UpdateDonorHomepage(
+            $mapTestimonials: [TestimonialInput!]
+            $carouselTestimonials: [TestimonialInput!]
+            $statMeasurements: StatisticMeasurement
+        ) {
+            updateDonorHomepage(
+                mapTestimonials: $mapTestimonials
+                carouselTestimonials: $carouselTestimonials
+                statMeasurements: $statMeasurements
+            ) {
+                map {
+                    testimonials {
+                        id
+                    }
+                }
+                testimonialCarousel {
+                    testimonials {
+                        id
+                    }
+                }
+                statistics {
+                    measurement
+                }
+            }
+        }
+    `;
+    const [mutateDonorHomepageConfig] = useMutation(updateDonorHomepageConfig, {
+        onCompleted: () => {
+            setShowSuccessAlert(true);
+        }
+    });
+
+    useEffect(() => {
+        if (!showSuccessAlert) return;
+        setTimeout(() => {
+            setShowSuccessAlert(false);
+        }, 5000);
+    }, [])
 
     const handleSave = () => {
         console.log("save");
+        if (formState == undefined) return;
         const statistics = formState.donorHomepageConfig.statistics;
-        const statMeasurements = {
+        const statMeasurements: {
+            [key: string]: string;
+        } = {
             REGULAR_DONORS: "",
             DIAPERS_DISTRIBUTED: "",
             CARE_CLOSET_VISITS: ""
-        }
-        statistics.forEach((statistic : Statistic) => {
+    };
+        statistics.forEach((statistic: Statistic) => {
             const type = statistic.type.toString();
             statMeasurements[type] = statistic.measurement;
-        })
-        mutateDonorHomepageConfig({ variables: {
-            mapTestimonials: formState.donorHomepageConfig.map.testimonials,
-            carouselTestimonials: formState.donorHomepageConfig.testimonialCarousel.testimonials,
-            statMeasurements: statMeasurements
-        } });
+        });
+        mutateDonorHomepageConfig({
+            variables: {
+                mapTestimonials: formState.donorHomepageConfig.map.testimonials,
+                carouselTestimonials: formState.donorHomepageConfig.testimonialCarousel.testimonials,
+                statMeasurements: statMeasurements
+            }
+        });
     };
 
     return (
         <div className="admin-edit-testimonials-page">
             <AdminPage>
-                <EditTestimonialsContext.Provider value={{ formState, setFormState }}>
-                    <div className="page-content">
-                        <div className="page-header">
-                            <h1>Editing Main Page</h1>
+                {formState == undefined ? (
+                    <div className="spinner">
+                        <Spinner animation="border" role="status" />
+                    </div>
+                ) : (
+                    <EditTestimonialsContext.Provider value={{ formState, setFormState }}>
+                        {showSuccessAlert && (
+                            <Alert variant="success"> Changes have been updated successfully! </Alert>
+                        )}
+                        <div className="page-content">
+                            <div className="page-header">
+                                <h1>Editing Main Page</h1>
+                            </div>
+                            <EditStatisticsSection />
+                            <EditClientStoriesSection/>
                         </div>
-                        <EditStatisticsSection />
-                        <EditClientStoriesSection />
-                    </div>
-                    <div className="page-footer">
-                        <Button className="save-button" text="Submit all changes" copyText="" onClick={handleSave} />
-                    </div>
-                </EditTestimonialsContext.Provider>
+                        <div className="page-footer">
+                            <Button
+                                className="save-button"
+                                text="Submit all changes"
+                                copyText=""
+                                onClick={handleSave}
+                            />
+                        </div>
+                    </EditTestimonialsContext.Provider>
+                )}
             </AdminPage>
         </div>
     );

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -1,5 +1,5 @@
+import { gql, useMutation } from "@apollo/client";
 import React, { FunctionComponent, useState } from "react";
-
 import AdminPage from "../components/layouts/AdminPage";
 import { Button } from "../components/atoms/Button";
 import DonorHomepageConfig from "../config/donorHomepageConfig.json";
@@ -33,9 +33,27 @@ export const EditTestimonialsContext = React.createContext<{
 
 const AdminEditTestimonialsPage: FunctionComponent = () => {
     const [formState, setFormState] = useState<EditTestimonialsFormState>(initialFormState);
+    const updateDonorHomepageConfig = gql`
+        mutation UpdateDonorHomepage($mapTestimonials: [TestimonialInput], $carouselTestimonials: [TestimonialInput], $statMeasurements : StatisticMeasurement) {
+            updateDonorHomepage(mapTestimonials: $mapTestimonials, carouselTestimonials: $carouselTestimonials, statMeasurements: $statMeasurements) {
+                
+            }
+        }
+    `;
+    const [mutateDonorHomepageConfig] = useMutation(updateDonorHomepageConfig);
+
 
     const handleSave = () => {
         console.log("save");
+        const statMeasurements = {
+            REGULAR_DONORS: "",
+            DIAPERS_DISTRIBUTED: "",
+            CARE_CLOSET_VISITS: ""
+        }
+        mutateDonorHomepageConfig({ variables: {
+            mapTestimonials: formState.donorHomepageConfig.map.testimonials,
+            carouselTestimonials: formState.donorHomepageConfig.
+        } });
     };
 
     return (

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -7,7 +7,6 @@ import { DonorHomepageConfig as DonorHomepageConfigType } from "../data/types/do
 import EditClientStoriesSection from "../components/molecules/EditClientStoriesSection";
 import EditStatisticsSection from "../components/molecules/EditStatisticsSection";
 import { Statistic } from "../data/types/donorHomepageConfig";
-import { useEffect } from "react";
 
 export type EditTestimonialsFormState = {
     careClosetVisitsStatError: string;

--- a/client/src/pages/AdminEditTestimonialsPage.tsx
+++ b/client/src/pages/AdminEditTestimonialsPage.tsx
@@ -120,6 +120,7 @@ const AdminEditTestimonialsPage: FunctionComponent = () => {
             const type = statistic.type.toString();
             statMeasurements[type] = statistic.measurement;
         });
+        console.log(statMeasurements); // ✅✅
         mutateDonorHomepageConfig({
             variables: {
                 mapTestimonials: formState.donorHomepageConfig.map.testimonials,

--- a/client/src/pages/style/AdminEditTestimonialsPage.scss
+++ b/client/src/pages/style/AdminEditTestimonialsPage.scss
@@ -1,6 +1,19 @@
 .admin-edit-testimonials-page {
     height: 100vh;
 
+    .spinner {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        height: 100vh;
+        width: 100vw;
+
+        .spinner-border {
+            width: 40px;
+            height: 40px;
+        }
+    }
+
     .admin-page,
     .admin-page-content {
         display: flex;

--- a/client/src/pages/style/AdminEditTestimonialsPage.scss
+++ b/client/src/pages/style/AdminEditTestimonialsPage.scss
@@ -14,6 +14,15 @@
         }
     }
 
+    .alert {
+        position: absolute;
+        align-self: center;
+        width: 32%;
+        border-radius: 5px;
+        margin-top: 20px;
+        text-align: center;
+    }
+
     .admin-page,
     .admin-page-content {
         display: flex;

--- a/server/scripts/seed.ts
+++ b/server/scripts/seed.ts
@@ -312,6 +312,13 @@ connectDB(async () => {
             exit();
         }
     });
+    DonorHomepage.deleteMany((err) => {
+        if (err) {
+            console.error("\x1b[31m", "Failed to delete all documents in 'donorHomepage' collection");
+            console.log("\x1b[0m");
+            exit();
+        }
+    });
 
     console.log("\x1b[34m", "Seeding data");
     console.log("\x1b[0m");


### PR DESCRIPTION
**Work Done:**
- Modified initialization of React context such that it updates when query is complete
- - Added spinner while query loading
- Used mutation to save changes to the config on ui
- Added success alert upon mutation

Miscellaneous:
- Adjusted word wrapping on each testimonial card 
- Fixed seeder to delete previous donorHomepage items made

Figma:
![image](https://user-images.githubusercontent.com/57274622/131416853-f78b321c-2579-456b-8afd-4f690c614bb6.png)

Implementation (will fix colours shortly): 
![image](https://user-images.githubusercontent.com/57274622/131416884-a73bcc38-a093-451a-a139-bcb736ebde73.png)
